### PR TITLE
Do not set sbbusyerror when reading sbcs

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -253,11 +253,7 @@ module dm_csrs #(
                 dm::HaltSum2: resp_queue_data = haltsum2;
                 dm::HaltSum3: resp_queue_data = haltsum3;
                 dm::SBCS: begin
-                    if (sbbusy_i) begin
-                        sbcs_d.sbbusyerror = 1'b1;
-                    end begin
-                        resp_queue_data = sbcs_q;
-                    end
+                    resp_queue_data = sbcs_q;
                 end
                 dm::SBAddress0: begin
                     // access while the SBA was busy


### PR DESCRIPTION
According to the RISC-V debug spec v0.13 sbbusyerror is defined as:

  Set when the debugger attempts to read data while a read is in
  progress, or when the debugger initiates a new access while one is
  already in progress (while sbbusy is set). It remains set until it’s
  explicitly cleared by the debugger. While this field is set, no more
  system bus accesses can be initiated by the Debug Module.

It is my understanding that reading sbcs does not constitute neither an
"attempt to read data" (from the bus) nor "a new access" (to the bus),
and hence sbbusyerror should not be updated.