### PR TITLE
Style: Use logical operators in if clauses

### DIFF
--- a/src/axi_adapter.sv
+++ b/src/axi_adapter.sv
@@ -326,7 +326,7 @@ module axi_adapter #(
     // Registers
     // ----------------
     always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
+        if (!rst_ni) begin
             // start in flushing state and initialize the memory
             state_q       <= IDLE;
             cnt_q         <= '0;

--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -503,7 +503,7 @@ module dm_csrs #(
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
         // PoR
-        if (~rst_ni) begin
+        if (!rst_ni) begin
             dmcontrol_q    <= '0;
             // this is the only write-able bit during reset
             cmderr_q       <= dm::CmdErrNone;
@@ -558,7 +558,7 @@ module dm_csrs #(
     generate
       for(genvar k=0;k < NrHarts;k++) begin
           always_ff @(posedge clk_i or negedge rst_ni) begin
-              if (~rst_ni) begin
+              if (!rst_ni) begin
                   havereset_q[k]  <= 1'b1;
               end else begin
                   havereset_q[k]  <= SelectableHarts[k] ? havereset_d[k]   : 1'b0;
@@ -575,7 +575,7 @@ module dm_csrs #(
 //pragma translate_off
 `ifndef VERILATOR
     haltsum: assert property (
-        @(posedge clk_i) disable iff (~rst_ni) (dmi_req_ready_o && dmi_req_valid_i && dtm_op == dm::DTM_READ) |->
+        @(posedge clk_i) disable iff (!rst_ni) (dmi_req_ready_o && dmi_req_valid_i && dtm_op == dm::DTM_READ) |->
             !({1'b0, dmi_req_i.addr} inside {dm::HaltSum0, dm::HaltSum1, dm::HaltSum2, dm::HaltSum3}))
                 else $warning("Haltsums have not been properly tested yet.");
 `endif

--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -418,7 +418,7 @@ module dm_mem #(
 
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
+        if (!rst_ni) begin
             fwd_rom_q       <= 1'b0;
             rdata_q         <= '0;
             state_q         <= Idle;
@@ -434,7 +434,7 @@ module dm_mem #(
     generate
       for(genvar k=0;k < NrHarts; k++) begin
           always_ff @(posedge clk_i or negedge rst_ni) begin
-              if (~rst_ni) begin
+              if (!rst_ni) begin
                   halted_q[k]   <= 1'b0;
                   resuming_q[k] <= 1'b0;
               end else begin

--- a/src/dm_sba.sv
+++ b/src/dm_sba.sv
@@ -140,7 +140,7 @@ module dm_sba #(
     end
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
+        if (!rst_ni) begin
             state_q <= Idle;
         end else begin
             state_q <= state_d;

--- a/src/dmi_jtag.sv
+++ b/src/dmi_jtag.sv
@@ -194,7 +194,7 @@ module dmi_jtag #(
     end
 
     always_ff @(posedge tck_i or negedge trst_ni) begin
-        if (~trst_ni) begin
+        if (!trst_ni) begin
             dr_q      <= '0;
             state_q   <= Idle;
             address_q <= '0;

--- a/src/dmi_jtag_tap.sv
+++ b/src/dmi_jtag_tap.sv
@@ -113,7 +113,7 @@ module dmi_jtag_tap #(
     end
 
     always_ff @(posedge tck_i, negedge trst_ni) begin
-        if (~trst_ni) begin
+        if (!trst_ni) begin
             jtag_ir_shift_q <= '0;
             jtag_ir_q       <= IDCODE;
         end else begin
@@ -226,7 +226,7 @@ module dmi_jtag_tap #(
 
     // TDO changes state at negative edge of TCK
     always_ff @(posedge tck_n, negedge trst_ni) begin
-        if (~trst_ni) begin
+        if (!trst_ni) begin
             td_o     <= 1'b0;
             tdo_oe_o <= 1'b0;
         end else begin
@@ -325,7 +325,7 @@ module dmi_jtag_tap #(
     end
 
     always_ff @(posedge tck_i or negedge trst_ni) begin
-        if (~trst_ni) begin
+        if (!trst_ni) begin
             tap_state_q <= RunTestIdle;
             idcode_q    <= IdcodeValue;
             bypass_q    <= 1'b0;


### PR DESCRIPTION
We prefer using only logical operators and not bitwise operators in if
clauses. The code follows this rule almost all the time, except for a
few cases. This patch fixes those.