### PR TITLE
Drive test_logic_reset_o signal

### DIFF
--- a/src/dmi_jtag_tap.sv
+++ b/src/dmi_jtag_tap.sv
@@ -253,6 +253,7 @@ module dmi_jtag_tap #(
         case (tap_state_q)
             TestLogicReset: begin
                 tap_state_d = (tms_i) ? TestLogicReset : RunTestIdle;
+                test_logic_reset_o = 1'b1;
             end
             RunTestIdle: begin
                 tap_state_d = (tms_i) ? SelectDrScan : RunTestIdle;


### PR DESCRIPTION
The test_logic_reset_o is used but never driven. It should signal a reset through the JTAG state machine.

I didn't double-check the logic completely, it could be that this signal should be used in more places where trst_n is currently used. I leave that for a follow-up, or maybe one of you knows what the logic should be exactly.