### PR TITLE
Initial Quartus compatibility

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -576,7 +576,9 @@ module dm_csrs #(
     end
 
 
-    for (genvar k = 0; k < NrHarts; k++) begin : gen_havereset
+    generate
+    genvar k;
+    for (k = 0; k < NrHarts; k++) begin : gen_havereset
         always_ff @(posedge clk_i or negedge rst_ni) begin
             if (!rst_ni) begin
                 havereset_q[k] <= 1'b1;
@@ -585,6 +587,7 @@ module dm_csrs #(
             end
         end
     end
+    endgenerate
 
 ///////////////////////////////////////////////////////
 // assertions

--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -455,7 +455,9 @@ module dm_mem #(
         end
     end
 
-    for (genvar k = 0; k < NrHarts; k++) begin : gen_halted
+    generate
+    genvar k;
+    for (k = 0; k < NrHarts; k++) begin : gen_halted
         always_ff @(posedge clk_i or negedge rst_ni) begin
             if (!rst_ni) begin
                 halted_q[k]   <= 1'b0;
@@ -466,5 +468,6 @@ module dm_mem #(
             end
         end
     end
+    endgenerate
 
 endmodule

--- a/src/dm_pkg.sv
+++ b/src/dm_pkg.sv
@@ -134,7 +134,7 @@ package dm;
 
     typedef enum logic [2:0] {  CmdErrNone, CmdErrBusy, CmdErrNotSupported,
                                 CmdErrorException, CmdErrorHaltResume,
-                                CmdErrorBus, CmdErrorOther = 7
+                                CmdErrorBus, CmdErrorOther = 3'd7
                              } cmderr_e;
 
     typedef struct packed {

--- a/src/dm_top.sv
+++ b/src/dm_top.sv
@@ -31,7 +31,7 @@ module dm_top #(
     output logic                  dmactive_o,  // debug module is active
     output logic [NrHarts-1:0]    debug_req_o, // async debug request
     input  logic [NrHarts-1:0]    unavailable_i, // communicate whether the hart is unavailable (e.g.: power down)
-    dm::hartinfo_t [NrHarts-1:0]  hartinfo_i,
+    input  dm::hartinfo_t [NrHarts-1:0] hartinfo_i,
 
     input  logic                  slave_req_i,
     input  logic                  slave_we_i,

--- a/src/dmi_jtag_tap.sv
+++ b/src/dmi_jtag_tap.sv
@@ -61,11 +61,11 @@ module dmi_jtag_tap #(
     tap_state_e tap_state_q, tap_state_d;
 
     typedef enum logic [IrLength-1:0] {
-        BYPASS0   = 'h0,
-        IDCODE    = 'h1,
-        DTMCSR    = 'h10,
-        DMIACCESS = 'h11,
-        BYPASS1   = 'h1f
+        BYPASS0   = 5'h0,
+        IDCODE    = 5'h1,
+        DTMCSR    = 5'h10,
+        DMIACCESS = 5'h11,
+        BYPASS1   = 5'h1f
     } ir_reg_e;
 
     typedef struct packed {


### PR DESCRIPTION
Initial non-breaking changes to support Quartus. In reference to: pulp-platform/pulpissimo#78

Fixed errors:

- `dm_csrs.sv`, `dm_mem.sv`: [unnamed loop generate, genvar inside for loop definition](https://marekpikula.github.io/quartus-sv-gotchas/Intel%20Quartus%20SystemVerilog%20gotchas.html#274-loop-generate-constructs-3)
- `dm_pkg.sv`, `dmi_jtag_tap.sv`: [integer value width in enum](https://marekpikula.github.io/quartus-sv-gotchas/Intel%20Quartus%20SystemVerilog%20gotchas.html#619-enumerations)
- `dm_top.sv`: [port direction ommited](https://marekpikula.github.io/quartus-sv-gotchas/Intel%20Quartus%20SystemVerilog%20gotchas.html#23223-rules-for-determining-port-kind-data-type-and-direction)