### PR TITLE
Fix too small cast

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -538,7 +538,7 @@ module dm_csrs #(
     // default assignment
     haltreq_o = '0;
     resumereq_o = '0;
-    if (selected_hart < HartSelLen'(NrHarts)) begin
+    if (selected_hart < (HartSelLen+1)'(NrHarts)) begin
       haltreq_o[selected_hart]   = dmcontrol_q.haltreq;
       resumereq_o[selected_hart] = dmcontrol_q.resumereq;
     end


### PR DESCRIPTION
HartSelLen is the number of bits required to represent NrHarts values,
but it is just shy of one bit to represent NrHarts itself.

@msfschaffner