### PR TITLE
Fix dm_csrs.sv

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -123,7 +123,7 @@ module dm_csrs #(
     haltsum1     = '0;
     hartsel_idx1 = hartsel_o[19:10];
 
-    for (int unsigned k = 0; k < NrHarts/2**5+1; k++) begin
+    for (int unsigned k = 0; k < NrHarts/2**5; k++) begin
       halted_flat1[k] = |halted_reshaped0[k];
     end
     halted_reshaped1 = halted_flat1;

--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -111,7 +111,7 @@ module dm_csrs #(
     hartsel_idx0        = hartsel_o[19:5];
     halted[NrHarts-1:0] = halted_i;
     halted_reshaped0    = halted;
-    if (hartsel_idx0 < 15'((NrHarts-1)/2**5)) begin
+    if (hartsel_idx0 < 15'((NrHarts-1)/2**5+1)) begin
       haltsum0 = halted_reshaped0[hartsel_idx0];
     end
   end

--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -111,7 +111,7 @@ module dm_csrs #(
     hartsel_idx0        = hartsel_o[19:5];
     halted[NrHarts-1:0] = halted_i;
     halted_reshaped0    = halted;
-    if (hartsel_idx0 < 15'((NrHarts-1)/2**5+1)) begin
+    if (hartsel_idx0 < 15'((NrHarts-1)/2**5)) begin
       haltsum0 = halted_reshaped0[hartsel_idx0];
     end
   end


### PR DESCRIPTION
fixed issue in cadence design flow. while elaborating genus complained "[CDFG-200]: could not resolve complex expression"

issue: halted_flat1 contained "X" at bit 33

solution: reduced loop counter by 1 so loop will be executed 32 times instead of 33 times.