### PR TITLE
Fixed a typo (: vs ::) in dp_mem.sv that crashed compilation

### DIFF
--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -252,7 +252,7 @@ module dm_mem #(
           // an exception occurred during execution
           ExceptionAddr: exception = 1'b1;
           // core can write data registers
-          [DataBaseAddr::DataEndAddr]: begin
+          [DataBaseAddr:DataEndAddr]: begin
             data_valid_o = 1'b1;
             for (int i = 0; i < $bits(be_i); i++) begin
               if (be_i[i]) begin


### PR DESCRIPTION
I am pretty sure DataBaseAddr is not refering to a package :)