### PR TITLE
Addded optional wrapper to make dm_top OBI compatible

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -9,6 +9,7 @@ sources:
     - src/dm_csrs.sv
     - src/dm_mem.sv
     - src/dm_top.sv
+    - src/dm_obi_top.sv
     - src/dmi_cdc.sv
     - src/dmi_jtag.sv
     - src/dmi_jtag_tap.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Optional wrapper `dm_obi_top.sv` that wraps `dm_top` providing an OBI compliant interface
 - `tb` that runs dm in conjunction with ri5cy and OpenOCD
 - `.travis-ci.yml` running `tb` with verilator
 

--- a/doc/debug-system.md
+++ b/doc/debug-system.md
@@ -275,6 +275,66 @@ input  logic [BusWidth/8-1:0] slave_be_i,
 input  logic [BusWidth-1:0]   slave_wdata_i,
 output logic [BusWidth-1:0]   slave_rdata_o
 ```
+### OBI Bus Interface (optional)
+
+A wrapper (called dm_obi_top) is provided which wraps the Debug Module (dm_top) and makes it OBI compliant. This wrapper
+can be ignored (and dm_top can be used directly instead) in case of non OBI compatible systems.
+
+The OBI (Open Bus Interface) specification is at https://github.com/openhwgroup/core-v-docs/blob/master/cores/cv32e40p/.
+
+The Debug Module connects to the system bus as device, exposing the debug memory (the Program Buffer and the Debug ROM),
+and as host for the System Bus Access (SBA) functionality. The bus interface is according to the OBI specification in both cases.
+The bus width is configurable to be 32 or 64 bit using the `BusWidth` parameter. The transfer identifier width is configurable
+using the `IdWidth` parameter.
+
+#### Host (Master) OBI Interface
+
+Compared to dm_top the slave interface of dm_obi_top has the following additional signals: slave_gnt_o, slave_rvalid_o, slave_aid_i,
+slave_rid_o. Compared to dm_top the master interface of dm_obi_top has some renamed signals (master_addr_o, master_rvalid_i, master_rdata_i
+instead of master_add_o, master_r_valid_i, master_r_rdata_i).
+
+Both interfaces are OBI compliant.
+
+**Signal** | **Width (bit)** | **Direction** | **Description**
+---------- | --------------- | ------------- | ---------------------------------------------------------------------------------------------------------
+req        | 1               | output        | Request valid, must stay high until gnt is high for one cycle
+addr       | BusWidth        | output        | Address, word aligned
+we         | BusWidth        | output        | Write Enable, high for writes, low for reads. Sent together with req
+be         | 1               | output        | Byte Enable. Is set for the bytes to write/read, sent together with req
+wdata      | BusWidth        | output        | Data to be written to device, sent together with req
+gnt        | 1               | input         | The device accepted the request. Host outputs may change in the next cycle.
+rvalid     | 1               | input         | r_rdata hold valid data when r_valid is high. This signal will be high for exactly one cycle per request.
+rdata      | BusWidth        | input         | Data read from the device
+
+No error response is currently implemented.
+
+**SystemVerilog interface definition (host side)**
+
+```verilog
+output logic                  master_req_o,
+output logic [BusWidth-1:0]   master_addr_o,
+output logic                  master_we_o,
+output logic [BusWidth-1:0]   master_wdata_o,
+output logic [BusWidth/8-1:0] master_be_o,
+input  logic                  master_gnt_i,
+input  logic                  master_rvalid_i,
+input  logic [BusWidth-1:0]   master_rdata_i
+```
+
+**SystemVerilog interface definition (device side)**
+
+```verilog
+input  logic                  slave_req_i,
+output logic                  slave_gnt_o,
+input  logic                  slave_we_i,
+input  logic [BusWidth-1:0]   slave_addr_i,
+input  logic [BusWidth/8-1:0] slave_be_i,
+input  logic [BusWidth-1:0]   slave_wdata_i,
+input  logic [IdWidth-1:0]    slave_aid_i,
+output logic                  slave_rvalid_o,
+output logic [BusWidth-1:0]   slave_rdata_o,
+output logic [IdWidth-1:0]    slave_rid_o
+```
 
 ### The Debug Module Interface (DMI)
 

--- a/src/dm_obi_top.sv
+++ b/src/dm_obi_top.sv
@@ -1,0 +1,181 @@
+// Copyright 2020 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License").
+//
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+//
+// You may obtain a copy of the License at:
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
+//                                                                            //
+// Design Name:    OBI Wrapper for Debug Module (dm_top)                      //
+// Project Name:   CV32E40P                                                   //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    Wrapper for the Debug Module (dm_top) which gives it an    //
+//                 OBI (Open Bus Interface) compatible interfaces so that it  //
+//                 can be integrated without further glue logic (other than   //
+//                 tie offs in an OBI compliant system.                       //
+//                                                                            //
+//                 This wrapper is only intended for OBI compliant systems;   //
+//                 in other systems the existing dm_top can be used as before //
+//                 and this wrapper can be ignored.                           //
+//                                                                            //
+//                 The OBI spec is available at:                              //
+//                                                                            //
+//                 - https://github.com/openhwgroup/core-v-docs/blob/master/  //
+//                   cores/cv32e40p/                                          //
+//                                                                            //
+//                 Compared to 'logint' interfaces of dm_top the following    //
+//                 signals are added:                                         //
+//                                                                            //
+//                 - slave_* OBI interface:                                   //
+//                                                                            //
+//                   - slave_gnt_o                                            //
+//                   - slave_rvalid_o                                         //
+//                   - slave_aid_i                                            //
+//                   - slave_rid_o                                            //
+//                                                                            //
+//                 Compared to 'logint' interfaces of dm_top the following    //
+//                 signals have been renamed:                                 //
+//                                                                            //
+//                 - master_* OBI interface:                                  //
+//                                                                            //
+//                   - Renamed master_add_o to master_addr_o                  //
+//                   - Renamed master_r_valid_i to master_rvalid_i            //
+//                   - Renamed master_r_rdata_i to master_rdata_i             //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module dm_obi_top #(
+  parameter int unsigned        IdWidth          = 1,                   // Width of aid/rid
+  parameter int unsigned        NrHarts          = 1,
+  parameter int unsigned        BusWidth         = 32,
+  parameter int unsigned        DmBaseAddress    = 'h1000,              // default to non-zero page
+  // Bitmask to select physically available harts for systems
+  // that don't use hart numbers in a contiguous fashion.
+  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}}
+) (
+  input  logic                  clk_i,                                  // clock
+  input  logic                  rst_ni,                                 // asynchronous reset active low, connect PoR here, not the system reset
+  input  logic                  testmode_i,
+  output logic                  ndmreset_o,                             // non-debug module reset
+  output logic                  dmactive_o,                             // debug module is active
+  output logic [NrHarts-1:0]    debug_req_o,                            // async debug request
+  input  logic [NrHarts-1:0]    unavailable_i,                          // communicate whether the hart is unavailable (e.g.: power down)
+  dm::hartinfo_t [NrHarts-1:0]  hartinfo_i,
+
+  input  logic                  slave_req_i,
+  output logic                  slave_gnt_o,                            // OBI grant for slave_req_i (not present on dm_top)
+  input  logic                  slave_we_i,
+  input  logic [BusWidth-1:0]   slave_addr_i,
+  input  logic [BusWidth/8-1:0] slave_be_i,
+  input  logic [BusWidth-1:0]   slave_wdata_i,
+  input  logic [IdWidth-1:0]    slave_aid_i,                            // Address phase transaction identifier (not present on dm_top)
+  output logic                  slave_rvalid_o,                         // OBI rvalid signal (end of response phase for reads/writes) (not present on dm_top)
+  output logic [BusWidth-1:0]   slave_rdata_o,
+  output logic [IdWidth-1:0]    slave_rid_o,                            // Response phase transaction identifier (not present on dm_top)
+
+  output logic                  master_req_o,
+  output logic [BusWidth-1:0]   master_addr_o,                          // Renamed according to OBI spec
+  output logic                  master_we_o,
+  output logic [BusWidth-1:0]   master_wdata_o,
+  output logic [BusWidth/8-1:0] master_be_o,
+  input  logic                  master_gnt_i,
+  input  logic                  master_rvalid_i,                        // Renamed according to OBI spec
+  input  logic [BusWidth-1:0]   master_rdata_i,                         // Renamed according to OBI spec
+
+  // Connection to DTM - compatible to RocketChip Debug Module
+  input  logic                  dmi_rst_ni,
+  input  logic                  dmi_req_valid_i,
+  output logic                  dmi_req_ready_o,
+  input  dm::dmi_req_t          dmi_req_i,
+
+  output logic                  dmi_resp_valid_o,
+  input  logic                  dmi_resp_ready_i,
+  output dm::dmi_resp_t         dmi_resp_o
+);
+
+  // Slave response phase (rvalid and identifier)
+  logic               slave_rvalid_q;
+  logic [IdWidth-1:0] slave_rid_q;
+
+  // dm_top instance
+  dm_top #(
+    .NrHarts                 ( NrHarts               ),
+    .BusWidth                ( BusWidth              ),
+    .DmBaseAddress           ( DmBaseAddress         ),
+    .SelectableHarts         ( SelectableHarts       )
+  ) i_dm_top (
+    .clk_i                   ( clk_i                 ),
+    .rst_ni                  ( rst_ni                ),
+    .testmode_i              ( testmode_i            ),
+    .ndmreset_o              ( ndmreset_o            ),
+    .dmactive_o              ( dmactive_o            ),
+    .debug_req_o             ( debug_req_o           ),
+    .unavailable_i           ( unavailable_i         ),
+    .hartinfo_i              ( hartinfo_i            ),
+
+    .slave_req_i             ( slave_req_i           ),
+    .slave_we_i              ( slave_we_i            ),
+    .slave_addr_i            ( slave_addr_i          ),
+    .slave_be_i              ( slave_be_i            ),
+    .slave_wdata_i           ( slave_wdata_i         ),
+    .slave_rdata_o           ( slave_rdata_o         ),
+
+    .master_req_o            ( master_req_o          ),
+    .master_add_o            ( master_addr_o         ),         // Renamed according to OBI spec
+    .master_we_o             ( master_we_o           ),
+    .master_wdata_o          ( master_wdata_o        ),
+    .master_be_o             ( master_be_o           ),
+    .master_gnt_i            ( master_gnt_i          ),
+    .master_r_valid_i        ( master_rvalid_i       ),         // Renamed according to OBI spec
+    .master_r_rdata_i        ( master_rdata_i        ),         // Renamed according to OBI spec
+
+    .dmi_rst_ni              ( dmi_rst_ni            ),
+    .dmi_req_valid_i         ( dmi_req_valid_i       ),
+    .dmi_req_ready_o         ( dmi_req_ready_o       ),
+    .dmi_req_i               ( dmi_req_i             ),
+
+    .dmi_resp_valid_o        ( dmi_resp_valid_o      ),
+    .dmi_resp_ready_i        ( dmi_resp_ready_i      ),
+    .dmi_resp_o              ( dmi_resp_o            )
+  );
+
+  // Extension to wrap dm_top as an OBI-compliant module
+  //
+  // dm_top has an implied rvalid pulse the cycle after its granted request.
+
+  // Registers
+  always_ff @(posedge clk_i or negedge rst_ni) begin : obi_regs
+    if (!rst_ni) begin
+      slave_rvalid_q   <= 1'b0;
+      slave_rid_q      <= 'b0;
+    end else begin
+      if (slave_req_i && slave_gnt_o) begin                     // 1 cycle pulse on rvalid for every granted request
+        slave_rvalid_q <= 1'b1;
+        slave_rid_q    <= slave_aid_i;                          // Mirror aid to rid
+      end else begin
+        slave_rvalid_q <= 1'b0;                                 // rid is don't care if rvalid = 0
+      end
+    end
+  end
+
+  assign slave_gnt_o = 1'b1;                                    // Always receptive to request (slave_req_i)
+  assign slave_rvalid_o = slave_rvalid_q;
+  assign slave_rid_o = slave_rid_q;
+
+endmodule : dm_obi_top

--- a/src_files.yml
+++ b/src_files.yml
@@ -6,6 +6,7 @@ riscv-dbg:
         src/dm_csrs.sv,
         src/dm_mem.sv,
         src/dm_top.sv,
+        src/dm_obi_top.sv,
         src/dmi_cdc.sv,
         src/dmi_jtag.sv,
         src/dmi_jtag_tap.sv,

--- a/tb/Makefile
+++ b/tb/Makefile
@@ -117,7 +117,7 @@ RTLSRC_DEBUG            := ../debug_rom/debug_rom.sv
 RTLSRC_DEBUG		+= $(addprefix ../src/,\
 				dm_csrs.sv dmi_cdc.sv dmi_jtag.sv \
 				dmi_jtag_tap.sv dm_mem.sv \
-				dm_sba.sv dm_top.sv)
+				dm_sba.sv dm_top.sv dm_obi_top.sv)
 
 RTLSRC			+= $(RTLSRC_RISCV) $(RTLSRC_COMMON) $(RTLSRC_TECH) $(RTLSRC_DEBUG)
 


### PR DESCRIPTION
Added wrapper (called dm_obi_top) which wraps the Debug Module (dm_top) and makes it OBI compliant. This wrapper can be ignored (and dm_top can be used directly instead) in case of non OBI compatible systems.

I did not modify dm_top itself at all so that current users of that module are not impacted. In case you think that we might as well do modifications in dm_top itself (and remove dm_obi_top again), please let me know and I can do that.

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>