### PR TITLE
add <WaitWriteValid> after <Write> in dmi_jtag state machine

### DIFF
--- a/src/dmi_jtag.sv
+++ b/src/dmi_jtag.sv
@@ -131,8 +131,15 @@ module dmi_jtag #(
 
       Write: begin
         dmi_req_valid = 1'b1;
-        // got a valid answer go back to idle
+        // request sent, wait for response before going back to idle
         if (dmi_req_ready) begin
+          state_d = WaitWriteValid;
+        end
+      end
+
+      WaitWriteValid: begin
+        // got a valid answer go back to idle
+        if (dmi_resp_valid) begin
           state_d = Idle;
         end
       end


### PR DESCRIPTION
A fix for cases where the core clock is slower than jtag clock (TCK)

The old SM did not wait for resp after write. 
This can cause a READ following a WRITE to get the response of the WRITE in case the jtag clock is much faster than the core clock.

The fix adds a WaitWriteValid state (the enum already had this state, but it was not implemented), so the next command can be issued only after the previous write got its response.
