### PR TITLE
return CmdErrBusy if accessing data or progbuf while command was executing

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -299,7 +299,7 @@ module dm_csrs #(
               cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
             end
           //An abstract command was executing while one of the data registers was read
-          end else begin
+          end else if (cmderr_q == dm::CmdErrNone) begin
               cmderr_d = dm::CmdErrBusy;
           end
         end
@@ -318,7 +318,7 @@ module dm_csrs #(
             cmd_valid_d = abstractauto_q.autoexecprogbuf[{1'b1, dmi_req_i.addr[3:0]}];
   
           //An abstract command was executing while one of the progbuf registers was read
-          end else begin
+          end else if (cmderr_q == dm::CmdErrNone) begin
             cmderr_d = dm::CmdErrBusy;
           end
         end
@@ -379,7 +379,7 @@ module dm_csrs #(
                 cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
               end
             //An abstract command was executing while one of the data registers was written
-            end else begin
+            end else if (cmderr_q == dm::CmdErrNone) begin
               cmderr_d = dm::CmdErrBusy;
             end
           end
@@ -439,7 +439,7 @@ module dm_csrs #(
             // range of autoexecprogbuf is 31:16
             cmd_valid_d = abstractauto_q.autoexecprogbuf[{1'b1, dmi_req_i.addr[3:0]}];
           //An abstract command was executing while one of the progbuf registers was written
-          end else begin
+          end else if (cmderr_q == dm::CmdErrNone) begin
             cmderr_d = dm::CmdErrBusy;
           end
         end


### PR DESCRIPTION
According to Debug spec (3.12.6):

> (cmderr=1 is returned when) An abstract command was executing while command, abstractcs, or abstractautowas written, or **when one of the data or progbufregisters was read or written**.

Current implementation only blocks writes and autoexec while busy, but does not set cmderr=1 (CmdErrBusy)


