### PR TITLE
Fix for issue #74; updates to use latest version of CV32E40P

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -630,19 +630,4 @@ module dm_csrs #(
     end
   end
 
-  ///////////////////////////////////////////////////////
-  // assertions
-  ///////////////////////////////////////////////////////
-
-  //pragma translate_off
-  `ifndef VERILATOR
-  haltsum: assert property (
-      @(posedge clk_i) disable iff (!rst_ni)
-          (dmi_req_ready_o && dmi_req_valid_i && dtm_op == dm::DTM_READ) |->
-              !({1'b0, dmi_req_i.addr} inside
-                  {dm::HaltSum0, dm::HaltSum1, dm::HaltSum2, dm::HaltSum3}))
-      else $warning("Haltsums have not been properly tested yet.");
-  `endif
-  //pragma translate_on
-
 endmodule : dm_csrs

--- a/src/dm_pkg.sv
+++ b/src/dm_pkg.sv
@@ -307,7 +307,7 @@ package dm;
     Write,
     WaitRead,
     WaitWrite
-  } sba_state_t;
+  } sba_state_e;
 
   // Instruction Generation Helpers
   function automatic logic [31:0] jal (logic [4:0]  rd,

--- a/src/dm_pkg.sv
+++ b/src/dm_pkg.sv
@@ -300,6 +300,14 @@ package dm;
     CSR_INSTRET        = 12'hC02
   } csr_reg_t;
 
+  // SBA state
+  typedef enum logic [2:0] {
+    Idle,
+    Read,
+    Write,
+    WaitRead,
+    WaitWrite
+  } sba_state_t;
 
   // Instruction Generation Helpers
   function automatic logic [31:0] jal (logic [4:0]  rd,

--- a/src/dm_sba.sv
+++ b/src/dm_sba.sv
@@ -53,8 +53,7 @@ module dm_sba #(
   output logic [2:0]             sberror_o // bus error occurred
 );
 
-  typedef enum logic [2:0] { Idle, Read, Write, WaitRead, WaitWrite } state_e;
-  state_e state_d, state_q;
+  dm::sba_state_t state_d, state_q;
 
   logic [BusWidth-1:0]           address;
   logic                          req;
@@ -64,7 +63,7 @@ module dm_sba #(
   logic [BusWidth/8-1:0]         be_mask;
   logic [$clog2(BusWidth/8)-1:0] be_idx;
 
-  assign sbbusy_o = logic'(state_q != Idle);
+  assign sbbusy_o = logic'(state_q != dm::Idle);
 
   always_comb begin : p_be_mask
     be_mask = '0;
@@ -100,51 +99,51 @@ module dm_sba #(
     state_d = state_q;
 
     unique case (state_q)
-      Idle: begin
+      dm::Idle: begin
         // debugger requested a read
-        if (sbaddress_write_valid_i && sbreadonaddr_i)  state_d = Read;
+        if (sbaddress_write_valid_i && sbreadonaddr_i)  state_d = dm::Read;
         // debugger requested a write
-        if (sbdata_write_valid_i) state_d = Write;
+        if (sbdata_write_valid_i) state_d = dm::Write;
         // perform another read
-        if (sbdata_read_valid_i && sbreadondata_i) state_d = Read;
+        if (sbdata_read_valid_i && sbreadondata_i) state_d = dm::Read;
       end
 
-      Read: begin
+      dm::Read: begin
         req = 1'b1;
         if (ReadByteEnable) be = be_mask;
-        if (gnt) state_d = WaitRead;
+        if (gnt) state_d = dm::WaitRead;
       end
 
-      Write: begin
+      dm::Write: begin
         req = 1'b1;
         we  = 1'b1;
         be = be_mask;
-        if (gnt) state_d = WaitWrite;
+        if (gnt) state_d = dm::WaitWrite;
       end
 
-      WaitRead: begin
+      dm::WaitRead: begin
         if (sbdata_valid_o) begin
-          state_d = Idle;
+          state_d = dm::Idle;
           // auto-increment address
           if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'b1 << sbaccess_i);
         end
       end
 
-      WaitWrite: begin
+      dm::WaitWrite: begin
         if (sbdata_valid_o) begin
-          state_d = Idle;
+          state_d = dm::Idle;
           // auto-increment address
           if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'b1 << sbaccess_i);
         end
       end
 
-      default: state_d = Idle; // catch parasitic state
+      default: state_d = dm::Idle; // catch parasitic state
     endcase
 
     // handle error case
-    if (sbaccess_i > 3 && state_q != Idle) begin
+    if (sbaccess_i > 3 && state_q != dm::Idle) begin
       req             = 1'b0;
-      state_d         = Idle;
+      state_d         = dm::Idle;
       sberror_valid_o = 1'b1;
       sberror_o       = 3'd3;
     end
@@ -153,7 +152,7 @@ module dm_sba #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin
-      state_q <= Idle;
+      state_q <= dm::Idle;
     end else begin
       state_q <= state_d;
     end
@@ -167,15 +166,5 @@ module dm_sba #(
   assign gnt             = master_gnt_i;
   assign sbdata_valid_o  = master_r_valid_i;
   assign sbdata_o        = master_r_rdata_i[BusWidth-1:0];
-
-
-  //pragma translate_off
-  `ifndef VERILATOR
-    // maybe bump severity to $error if not handled at runtime
-    dm_sba_access_size: assert property(@(posedge clk_i) disable iff (dmactive_i !== 1'b0)
-        (state_d != Idle) |-> (sbaccess_i < 4))
-            else $warning ("accesses > 8 byte not supported at the moment");
-  `endif
-  //pragma translate_on
 
 endmodule : dm_sba

--- a/src/dm_sba.sv
+++ b/src/dm_sba.sv
@@ -53,7 +53,7 @@ module dm_sba #(
   output logic [2:0]             sberror_o // bus error occurred
 );
 
-  dm::sba_state_t state_d, state_q;
+  dm::sba_state_e state_d, state_q;
 
   logic [BusWidth-1:0]           address;
   logic                          req;

--- a/src/dm_top.sv
+++ b/src/dm_top.sv
@@ -215,18 +215,4 @@ module dm_top #(
     .rdata_o                 ( slave_rdata_o         )
   );
 
-
-`ifndef VERILATOR
-  initial begin
-    assert (BusWidth == 32 || BusWidth == 64)
-        else $fatal(1, "DM needs a bus width of either 32 or 64 bits");
-    #0; // Avoid initial X's on hartinfo_i
-    // Fail if the DM is not located on the zero page and one hart doesn't have two scratch registers.
-    for (int i = 0; i < NrHarts; i++) begin
-      assert ((DmBaseAddress > 0 && hartinfo_i[i].nscratch >= 2) || (DmBaseAddress == 0 && hartinfo_i[i].nscratch >= 1))
-        else $fatal(1, "If the DM is not located at the zero page each hart needs at lest two scratch registers %d %d",i, hartinfo_i[i].nscratch );
-    end
-  end
-`endif
-
 endmodule : dm_top

--- a/sva/dm_csrs_sva.sv
+++ b/sva/dm_csrs_sva.sv
@@ -1,0 +1,55 @@
+// Copyright 2020 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License").
+//
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+//
+// You may obtain a copy of the License at:
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
+//                                                                            //
+// Design Name:    dm_csrs_sva                                                //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    SystemVerilog assertions for dm_csrs                       //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module dm_csrs_sva #(
+  parameter int unsigned        NrHarts          = 1,
+  parameter int unsigned        BusWidth         = 32,
+  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}}
+)(
+  input logic           clk_i,
+  input logic           rst_ni,
+  input logic           dmi_req_valid_i,
+  input logic           dmi_req_ready_o,
+  input dm::dmi_req_t   dmi_req_i,
+  input dm::dtm_op_e    dtm_op
+);
+
+  ///////////////////////////////////////////////////////
+  // Assertions
+  ///////////////////////////////////////////////////////
+
+  haltsum: assert property (
+      @(posedge clk_i) disable iff (!rst_ni)
+          (dmi_req_ready_o && dmi_req_valid_i && dtm_op == dm::DTM_READ) |->
+              !({1'b0, dmi_req_i.addr} inside
+                  {dm::HaltSum0, dm::HaltSum1, dm::HaltSum2, dm::HaltSum3}))
+      else $warning("Haltsums have not been properly tested yet.");
+
+endmodule: dm_csrs_sva

--- a/sva/dm_sba_sva.sv
+++ b/sva/dm_sba_sva.sv
@@ -1,0 +1,50 @@
+// Copyright 2020 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License").
+//
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+//
+// You may obtain a copy of the License at:
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
+//                                                                            //
+// Design Name:    dm_sba_sva                                                 //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    SystemVerilog assertions for dm_sba                        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module dm_sba_sva #(
+  parameter int unsigned BusWidth = 32,
+  parameter bit          ReadByteEnable = 1
+)(
+  input logic           clk_i,
+  input logic           dmactive_i,
+  input logic [2:0]     sbaccess_i,
+  input dm::sba_state_t state_d
+);
+
+  ///////////////////////////////////////////////////////
+  // Assertions
+  ///////////////////////////////////////////////////////
+
+  // maybe bump severity to $error if not handled at runtime
+  dm_sba_access_size: assert property(@(posedge clk_i) disable iff (dmactive_i !== 1'b0)
+      (state_d != dm::Idle) |-> (sbaccess_i < 4))
+          else $warning ("accesses > 8 byte not supported at the moment");
+
+endmodule: dm_sba_sva

--- a/sva/dm_sba_sva.sv
+++ b/sva/dm_sba_sva.sv
@@ -35,7 +35,7 @@ module dm_sba_sva #(
   input logic           clk_i,
   input logic           dmactive_i,
   input logic [2:0]     sbaccess_i,
-  input dm::sba_state_t state_d
+  input dm::sba_state_e state_d
 );
 
   ///////////////////////////////////////////////////////

--- a/sva/dm_top_sva.sv
+++ b/sva/dm_top_sva.sv
@@ -1,0 +1,65 @@
+// Copyright 2020 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License").
+//
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+//
+// You may obtain a copy of the License at:
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
+//                                                                            //
+// Design Name:    dm_top_sva                                                 //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    SystemVerilog assertions for dm_top                        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module dm_top_sva
+#(
+  parameter int unsigned        NrHarts          = 1,
+  parameter int unsigned        BusWidth         = 32,
+  parameter int unsigned        DmBaseAddress    = 'h1000,
+  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}},
+  parameter bit                 ReadByteEnable   = 1
+)(
+  input logic           clk_i,
+  input logic           rst_ni,
+  input dm::hartinfo_t [NrHarts-1:0] hartinfo_i
+);
+
+  ///////////////////////////////////////////////////////
+  // Assertions
+  ///////////////////////////////////////////////////////
+
+  // Check that BusWidth is supported
+  bus_width: assert property (
+      @(posedge clk_i) disable iff (!rst_ni)
+          (1'b1) |-> (BusWidth == 32 || BusWidth == 64))
+      else $fatal(1, "DM needs a bus width of either 32 or 64 bits");
+
+  // Fail if the DM is not located on the zero page and one hart doesn't have two scratch registers.
+  genvar i;
+  generate for (i = 0; i < NrHarts; i++)
+    begin
+      hart_info: assert property (
+          @(posedge clk_i) disable iff (!rst_ni)
+              (1'b1) |-> ((DmBaseAddress > 0 && hartinfo_i[i].nscratch >= 2) || (DmBaseAddress == 0 && hartinfo_i[i].nscratch >= 1)))
+          else $fatal(1, "If the DM is not located at the zero page each hart needs at least two scratch registers %d %d",i, hartinfo_i[i].nscratch);
+    end
+  endgenerate
+
+endmodule: dm_top_sva

--- a/tb/Makefile
+++ b/tb/Makefile
@@ -61,6 +61,9 @@ RTLSRC_TB		:= boot_rom.sv \
 				dp_ram.sv \
 				mm_ram.sv \
 				SimJTAG.sv \
+				../sva/dm_top_sva.sv \
+				../sva/dm_csrs_sva.sv \
+				../sva/dm_sba_sva.sv \
 				tb_test_env.sv \
 				tb_top.sv
 
@@ -75,38 +78,38 @@ RTLSRC_INCDIR           := riscv/rtl/include
 
 RTLSRC_FPNEW_PKG	:= fpnew/src/fpnew_pkg.sv
 RTLSRC_RISCV_PKG	+= $(addprefix riscv/rtl/include/,\
-				apu_core_package.sv riscv_defines.sv \
-				riscv_tracer_defines.sv)
+				cv32e40p_apu_core_pkg.sv cv32e40p_pkg.sv \
+				../../bhv/include/cv32e40p_tracer_pkg.sv)
 RTLSRC_DM_PKG		+= ../src/dm_pkg.sv
 
 RTLSRC_PKG 		= $(RTLSRC_FPNEW_PKG) dm_tb_pkg.sv $(RTLSRC_RISCV_PKG) $(RTLSRC_DM_PKG)
 RTLSRC_RISCV		:= $(addprefix riscv/rtl/,\
-				cv32e40p_sim_clock_gating.sv \
-				register_file_test_wrap.sv \
-				riscv_tracer.sv \
-				riscv_register_file.sv \
-				riscv_alu.sv \
-				riscv_alu_basic.sv \
-				riscv_alu_div.sv \
-				riscv_compressed_decoder.sv \
-				riscv_controller.sv \
-				riscv_cs_registers.sv \
-				riscv_decoder.sv \
-				riscv_int_controller.sv \
-				riscv_ex_stage.sv \
-				riscv_hwloop_controller.sv \
-				riscv_hwloop_regs.sv \
-				riscv_id_stage.sv \
-				riscv_if_stage.sv \
-				riscv_load_store_unit.sv \
-				riscv_mult.sv \
-				riscv_prefetch_buffer.sv \
-				riscv_prefetch_L0_buffer.sv \
-				riscv_core.sv \
-				riscv_apu_disp.sv \
-				riscv_fetch_fifo.sv \
-				riscv_L0_buffer.sv \
-				riscv_pmp.sv)
+				../bhv/cv32e40p_sim_clock_gate.sv \
+				../bhv/cv32e40p_tracer.sv \
+				cv32e40p_if_stage.sv \
+				cv32e40p_cs_registers.sv \
+				cv32e40p_register_file_ff.sv \
+				cv32e40p_load_store_unit.sv \
+				cv32e40p_id_stage.sv \
+				cv32e40p_aligner.sv \
+				cv32e40p_decoder.sv \
+				cv32e40p_compressed_decoder.sv \
+				cv32e40p_fifo.sv \
+				cv32e40p_prefetch_buffer.sv \
+				cv32e40p_hwloop_regs.sv \
+				cv32e40p_mult.sv \
+				cv32e40p_int_controller.sv \
+				cv32e40p_ex_stage.sv \
+				cv32e40p_alu_div.sv \
+				cv32e40p_alu.sv \
+				cv32e40p_ff_one.sv \
+				cv32e40p_popcnt.sv \
+				cv32e40p_apu_disp.sv \
+				cv32e40p_controller.sv \
+				cv32e40p_obi_interface.sv \
+				cv32e40p_prefetch_controller.sv \
+				cv32e40p_sleep_unit.sv \
+				cv32e40p_core.sv)
 RTLSRC_COMMON           := $(addprefix common_cells/src/,\
 				cdc_2phase.sv fifo_v2.sv fifo_v3.sv\
 				rstgen.sv rstgen_bypass.sv)
@@ -122,7 +125,7 @@ RTLSRC_DEBUG		+= $(addprefix ../src/,\
 RTLSRC			+= $(RTLSRC_RISCV) $(RTLSRC_COMMON) $(RTLSRC_TECH) $(RTLSRC_DEBUG)
 
 # versions for this tb
-RI5CY_SHA               = d049690e7867291830631db7dbeb47c92718ed9e
+CV32E40P_SHA            = f9d63290eea738cb0a6fbf1e77bbd18555015a03
 FPU_SHA                 = v0.6.1
 COMMON_SHA              = 337f54a7cdfdad78b124cbdd2a627db3e0939141
 TECH_SHA                = b35652608124b7ea813818b14a00ca76edd7599d
@@ -228,7 +231,7 @@ $(RTLSRC_TECH):
 
 $(RTLSRC_RISCV_PKG) $(RTLSRC_RISCV):
 	git clone https://github.com/openhwgroup/cv32e40p.git riscv
-	cd riscv/ && git checkout $(RI5CY_SHA)
+	cd riscv/ && git checkout $(CV32E40P_SHA)
 
 # openocd server
 remote_bitbang/librbs_veri.so: INCLUDE_DIRS =./ $(VSIM_HOME)/include

--- a/tb/Makefile
+++ b/tb/Makefile
@@ -71,7 +71,6 @@ RTLSRC_VERI_TB          := boot_rom.sv \
 				dp_ram.sv \
 				mm_ram.sv \
 				SimJTAG.sv \
-				tb_test_env.sv \
 				tb_top_verilator.sv
 
 RTLSRC_INCDIR           := riscv/rtl/include

--- a/tb/tb_test_env.sv
+++ b/tb/tb_test_env.sv
@@ -15,7 +15,6 @@ module tb_test_env #(
     parameter int unsigned INSTR_RDATA_WIDTH = 32,
     parameter int unsigned RAM_ADDR_WIDTH = 20,
     parameter logic [31:0] BOOT_ADDR = 'h80,
-    parameter bit          PULP_SECURE = 1,
     parameter bit          JTAG_BOOT = 1,
     parameter int unsigned OPENOCD_PORT = 0,
     parameter bit          A_EXTENSION = 0
@@ -35,9 +34,10 @@ module tb_test_env #(
     localparam CLUSTER_ID         = 6'd0;
     localparam CORE_ID            = 4'd0;
 
-    localparam CORE_MHARTID       = {CLUSTER_ID, 1'b0, CORE_ID};
+    localparam CORE_MHARTID       = {21'b0, CLUSTER_ID, 1'b0, CORE_ID};
     localparam NrHarts                               = 1;
     localparam logic [NrHarts-1:0] SELECTABLE_HARTS  = 1 << CORE_MHARTID;
+    localparam HARTINFO           = {8'h0, 4'h2, 3'b0, 1'b1, dm::DataCount, dm::DataAddr};
 
     // signals connecting core to memory
     logic                        instr_req;
@@ -99,30 +99,29 @@ module tb_test_env #(
     logic [0:4]                  irq_id_in;
     logic                        irq_ack;
     logic [0:4]                  irq_id_out;
-    logic                        irq_sec;
 
     // make jtag bridge work
     assign sim_jtag_enable = JTAG_BOOT;
 
-    // interrupts (only timer for now)
-    assign irq_sec = '0;
-
     // instantiate the core
-    riscv_core #(
-        .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
-        .PULP_SECURE(PULP_SECURE),
-        .A_EXTENSION(A_EXTENSION),
-        .FPU(0)
+    cv32e40p_core #(
+        .PULP_XPULP             ( 0                     ),
+        .PULP_CLUSTER           ( 0                     ),
+        .FPU                    ( 0                     ),
+        .PULP_ZFINX             ( 0                     ),
+        .NUM_MHPMCOUNTERS       ( 1                     )
     ) riscv_core_i (
         .clk_i                  ( clk_i                 ),
         .rst_ni                 ( ndmreset_n            ),
 
-        .clock_en_i             ( '1                    ),
-        .test_en_i              ( '0                    ),
+        .pulp_clock_en_i        ( '1                    ),
+        .scan_cg_en_i           ( '0                    ),
 
         .boot_addr_i            ( BOOT_ADDR             ),
-        .core_id_i              ( CORE_ID               ),
-        .cluster_id_i           ( CLUSTER_ID            ),
+        .mtvec_addr_i           ( 32'h00000000          ),
+        .dm_halt_addr_i         ( 32'h1A110800          ),
+        .hart_id_i              ( CORE_MHARTID          ),
+        .dm_exception_addr_i    ( 32'h00000000          ),
 
         .instr_addr_o           ( instr_addr            ),
         .instr_req_o            ( instr_req             ),
@@ -138,7 +137,6 @@ module tb_test_env #(
         .data_rdata_i           ( data_rdata            ),
         .data_gnt_i             ( data_gnt              ),
         .data_rvalid_i          ( data_rvalid           ),
-        .data_atop_o            (                       ),
 
         .apu_master_req_o       (                       ),
         .apu_master_ready_o     (                       ),
@@ -151,27 +149,14 @@ module tb_test_env #(
         .apu_master_result_i    (                       ),
         .apu_master_flags_i     (                       ),
 
-
-        .irq_software_i         ( 1'b0                  ),
-        .irq_timer_i            ( 1'b0                  ),
-        .irq_external_i         ( 1'b0                  ),
-        .irq_fast_i             ( 15'b0                 ),
-        .irq_nmi_i              ( 1'b0                  ),
-        .irq_fastx_i            ( 32'b0                 ),
-
+        .irq_i                  ( 32'b0                 ),
         .irq_ack_o              ( irq_ack               ),
         .irq_id_o               ( irq_id_out            ),
-        .irq_sec_i              ( irq_sec               ),
-
-        .sec_lvl_o              ( sec_lvl_o             ),
 
         .debug_req_i            ( dm_debug_req[CORE_MHARTID] ),
 
         .fetch_enable_i         ( fetch_enable_i        ),
-        .core_busy_o            ( core_busy_o           ),
-
-        .ext_perf_counters_i    (                       ),
-        .fregfile_disable_i     ( 1'b0                  )
+        .core_sleep_o           ( core_sleep_o          )
     );
 
     // this handles read to RAM and memory mapped pseudo peripherals
@@ -265,7 +250,7 @@ module tb_test_env #(
        .dmactive_o        (                   ), // active debug session TODO
        .debug_req_o       ( dm_debug_req      ),
        .unavailable_i     ( ~SELECTABLE_HARTS ),
-       .hartinfo_i        ( '0                ),
+       .hartinfo_i        ( HARTINFO          ),
 
        .slave_req_i       ( dm_req            ),
        .slave_we_i        ( dm_we             ),
@@ -291,6 +276,34 @@ module tb_test_env #(
        .dmi_resp_ready_i  ( jtag_resp_ready   ),
        .dmi_resp_o        ( debug_resp        )
     );
+
+    ///////////////////////////////////////////////////////
+    // Bind RTL assertions to Debug Module
+    ///////////////////////////////////////////////////////
+
+    bind dm_top
+      dm_top_sva
+      #(
+       .NrHarts           ( NrHarts           ),
+       .BusWidth          ( BusWidth          ),
+       .SelectableHarts   ( SelectableHarts   ))
+       i_dm_top_sva (.*);
+
+    bind dm_csrs
+      dm_csrs_sva
+      #(
+       .NrHarts           ( NrHarts           ),
+       .BusWidth          ( BusWidth          ),
+       .SelectableHarts   ( SelectableHarts   ))
+       i_dm_csrs_sva (.*);
+
+    bind dm_sba
+      dm_sba_sva
+      #(
+       .BusWidth          ( BusWidth          ),
+       .ReadByteEnable    ( ReadByteEnable    ))
+       i_dm_sba_sva (.*);
+
 
     // grant in the same cycle
     assign dm_gnt = dm_req;

--- a/tb/tb_top.sv
+++ b/tb/tb_top.sv
@@ -124,7 +124,6 @@ module tb_top #(
         .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
         .RAM_ADDR_WIDTH (RAM_ADDR_WIDTH),
         .BOOT_ADDR (BOOT_ADDR),
-        .PULP_SECURE (1),
         .JTAG_BOOT (JTAG_BOOT),
         .OPENOCD_PORT (OPENOCD_PORT)
     ) tb_test_env_i(

--- a/tb/waves.tcl
+++ b/tb/waves.tcl
@@ -23,8 +23,7 @@
 # }
 
 # add fc
-set rvcores [find instances -recursive -bydu riscv_core -nodu]
-set fpuprivate [find instances -recursive -bydu fpu_private]
+set rvcores [find instances -recursive -bydu cv32e40p_core -nodu]
 set tb_top [find instances -recursive -bydu tb_top -nod]
 set mm_ram [find instances -recursive -bydu mm_ram -nod]
 set dp_ram [find instances -recursive -bydu dp_ram -nod]
@@ -48,32 +47,22 @@ if {$dp_ram ne ""} {
 }
 
 if {$rvcores ne ""} {
-  set rvprefetch [find instances -recursive -bydu riscv_prefetch_L0_buffer -nodu]
-
   add wave -group "Core"                                     $rvcores/*
-  add wave -group "IF Stage" -group "Hwlp Ctrl"              $rvcores/if_stage_i/hwloop_controller_i/*
-  if {$rvprefetch ne ""} {
-    add wave -group "IF Stage" -group "Prefetch" -group "L0"   $rvcores/if_stage_i/prefetch_128/prefetch_buffer_i/L0_buffer_i/*
-    add wave -group "IF Stage" -group "Prefetch"               $rvcores/if_stage_i/prefetch_128/prefetch_buffer_i/*
-  } {
-    add wave -group "IF Stage" -group "Prefetch" -group "FIFO" $rvcores/if_stage_i/prefetch_32/prefetch_buffer_i/fifo_i/*
-    add wave -group "IF Stage" -group "Prefetch"               $rvcores/if_stage_i/prefetch_32/prefetch_buffer_i/*
-  }
+  add wave -group "IF Stage" -group "Prefetch"               $rvcores/if_stage_i/prefetch_buffer_i/*
+  add wave -group "IF Stage" -group "Prefetch" -group "FIFO" $rvcores/if_stage_i/prefetch_buffer_i/fifo_i/*
+  add wave -group "IF Stage" -group "Prefetch" -group "OBI"  $rvcores/if_stage_i/prefetch_buffer_i/instruction_obi_i/*
   add wave -group "IF Stage"                                 $rvcores/if_stage_i/*
+  add wave -group "Aligner"                                  $rvcores/if_stage_i/aligner_i/*
+  add wave -group "RVCDecoder"                               $rvcores/if_stage_i/compressed_decoder_i/*
   add wave -group "ID Stage"                                 $rvcores/id_stage_i/*
-  add wave -group "RF"                                       $rvcores/id_stage_i/registers_i/riscv_register_file_i/mem
-  add wave -group "RF_FP"                                    $rvcores/id_stage_i/registers_i/riscv_register_file_i/mem_fp
+  add wave -group "RF"                                       $rvcores/id_stage_i/register_file_i/mem
+  add wave -group "RF_FP"                                    $rvcores/id_stage_i/register_file_i/mem_fp
   add wave -group "Decoder"                                  $rvcores/id_stage_i/decoder_i/*
   add wave -group "Controller"                               $rvcores/id_stage_i/controller_i/*
   add wave -group "Int Ctrl"                                 $rvcores/id_stage_i/int_controller_i/*
-  add wave -group "Hwloop Regs"                              $rvcores/id_stage_i/hwloop_regs_i/*
   add wave -group "EX Stage" -group "ALU"                    $rvcores/ex_stage_i/alu_i/*
-  add wave -group "EX Stage" -group "ALU_DIV"                $rvcores/ex_stage_i/alu_i/int_div/div_i/*
+  add wave -group "EX Stage" -group "ALU_DIV"                $rvcores/ex_stage_i/alu_i/alu_div_i/*
   add wave -group "EX Stage" -group "MUL"                    $rvcores/ex_stage_i/mult_i/*
-  if {$fpuprivate ne ""} {
-    add wave -group "EX Stage" -group "APU_DISP"             $rvcores/ex_stage_i/genblk1/apu_disp_i/*
-    add wave -group "EX Stage" -group "FPU"                  $rvcores/ex_stage_i/genblk1/genblk1/fpu_i/*
-  }
   add wave -group "EX Stage"                                 $rvcores/ex_stage_i/*
   add wave -group "LSU"                                      $rvcores/load_store_unit_i/*
   add wave -group "CSR"                                      $rvcores/cs_registers_i/*


### PR DESCRIPTION
This pull requests addresses the following:

- Fix for issue #74 
- Updates to make Debug Module testbench work together with most recent version of RI5CY/CV32E40P
- Updates to move non-RTL code out of RTL files

Note that the original `ifndef VERILATOR to guard assertions causes problems for synthesis tools. Either the synthesis tool would object against the assertions or you would have to define VERILATOR (both of which are not okay). Now binding the assertions to the RTL for a cleaner split between assertions and RTL. Also got rid of the #0 construct in the assertions as that was not a clean solution. 

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>