### PR TITLE
Make DM support CPU with bus width different from core data width

### DIFF
--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -19,6 +19,7 @@
 module dm_mem #(
     parameter int                 NrHarts          = -1,
     parameter int                 BusWidth         = -1,
+    parameter int                 Xlen             = -1,
     parameter logic [NrHarts-1:0] SelectableHarts  = -1
 )(
     input  logic                             clk_i,       // Clock
@@ -58,7 +59,7 @@ module dm_mem #(
 );
 
     localparam int HartSelLen = (NrHarts == 1) ? 1 : $clog2(NrHarts);
-    localparam int MaxAar = (BusWidth == 64) ? 4 : 3;
+    localparam int MaxAar = (Xlen == 64) ? 4 : 3;
     localparam DbgAddressBits = 12;
     localparam logic [DbgAddressBits-1:0] DataBase = (dm::DataAddr);
     localparam logic [DbgAddressBits-1:0] DataEnd = (dm::DataAddr + 4*dm::DataCount);

--- a/src/dm_top.sv
+++ b/src/dm_top.sv
@@ -20,6 +20,7 @@
 module dm_top #(
     parameter int                 NrHarts          = 1,
     parameter int                 BusWidth         = 32,
+    parameter int                 Xlen             = 32,
     parameter logic [NrHarts-1:0] SelectableHarts  = 1  // Bitmask to select physically available harts for systems
                                                         // that don't use hart numbers in a contiguous fashion.
 
@@ -183,6 +184,7 @@ module dm_top #(
     dm_mem #(
         .NrHarts(NrHarts),
         .BusWidth(BusWidth),
+        .Xlen(Xlen),
         .SelectableHarts(SelectableHarts)
     ) i_dm_mem (
         .clk_i                   ( clk_i                 ),


### PR DESCRIPTION
Hi @zarubaf 

This PR is relative to the issue #541 of openHWgroup/CVA6

Cheers
Jean-Roch

