### PR TITLE
Bender.yml: Fix path to `one scratch` debug rom

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -5,7 +5,7 @@ sources:
   files:
     - src/dm_pkg.sv
     - debug_rom/debug_rom.sv
-    - debug_rom/debug_rom_snd_scratch.sv
+    - debug_rom/debug_rom_one_scratch.sv
     - src/dm_csrs.sv
     - src/dm_mem.sv
     - src/dm_top.sv


### PR DESCRIPTION
Somehow this got lost when I made the pull request earlier.