### PR TITLE
add sbaccess8 and sbaccess16 support (and sbaccess32 support for BusWidth=64) 

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -529,12 +529,11 @@ module dm_csrs #(
     sbcs_d.sbversion            = 3'b1;
     sbcs_d.sbbusy               = sbbusy_i;
     sbcs_d.sbasize              = $bits(sbcs_d.sbasize)'(BusWidth);
-    sbcs_d.sbaccess128          = 1'b0;
-    sbcs_d.sbaccess64           = logic'(BusWidth == 32'd64);
-    sbcs_d.sbaccess32           = logic'(BusWidth == 32'd32);
-    sbcs_d.sbaccess16           = 1'b0;
-    sbcs_d.sbaccess8            = 1'b0;
-    sbcs_d.sbaccess             = (BusWidth == 32'd64) ? 3'd3 : 3'd2;
+    sbcs_d.sbaccess128          = logic'(BusWidth >= 32'd128);
+    sbcs_d.sbaccess64           = logic'(BusWidth >= 32'd64);
+    sbcs_d.sbaccess32           = logic'(BusWidth >= 32'd32);
+    sbcs_d.sbaccess16           = logic'(BusWidth >= 32'd16);
+    sbcs_d.sbaccess8            = logic'(BusWidth >= 32'd8);
   end
 
   // output multiplexer

--- a/src/dm_sba.sv
+++ b/src/dm_sba.sv
@@ -141,11 +141,19 @@ module dm_sba #(
     endcase
 
     // handle error case
-    if (sbaccess_i > 3 && state_q != dm::Idle) begin
+    if (sbaccess_i > $clog2(BusWidth/8) && state_q != dm::Idle) begin
       req             = 1'b0;
       state_d         = dm::Idle;
       sberror_valid_o = 1'b1;
-      sberror_o       = 3'd3;
+      sberror_o       = 3'd4; // unsupported size was requested
+    end
+
+    //if sbaccess_i lsbs of address are not 0 - report misalignment error
+    if (|(sbaddress_i & ~('1<<sbaccess_i)) && state_q != dm::Idle) begin
+      req             = 1'b0;
+      state_d         = dm::Idle;
+      sberror_valid_o = 1'b1;
+      sberror_o       = 3'd3; // alignment error
     end
     // further error handling should go here ...
   end

--- a/src/dm_sba.sv
+++ b/src/dm_sba.sv
@@ -165,6 +165,6 @@ module dm_sba #(
   assign master_be_o     = be[BusWidth/8-1:0];
   assign gnt             = master_gnt_i;
   assign sbdata_valid_o  = master_r_valid_i;
-  assign sbdata_o        = master_r_rdata_i[BusWidth-1:0];
+  assign sbdata_o        = master_r_rdata_i[BusWidth-1:0] >> (8*(be_idx & '1<<sbaccess_i));
 
 endmodule : dm_sba

--- a/src/dm_sba.sv
+++ b/src/dm_sba.sv
@@ -161,7 +161,7 @@ module dm_sba #(
   assign master_req_o    = req;
   assign master_add_o    = address[BusWidth-1:0];
   assign master_we_o     = we;
-  assign master_wdata_o  = sbdata_i[BusWidth-1:0];
+  assign master_wdata_o  = sbdata_i[BusWidth-1:0] << (8*(be_idx & ('1<<sbaccess_i)));
   assign master_be_o     = be[BusWidth/8-1:0];
   assign gnt             = master_gnt_i;
   assign sbdata_valid_o  = master_r_valid_i;


### PR DESCRIPTION
### dm_csrs:
* status bits ```sbaccess8``` and ```sbaccess16``` were hard-wired to 0, and only one of ```sbaccess32``` and ```sbaccess64``` was 1, according to BusWidth. --> changed all ```sbaccessX``` fields to `(BusWidth>=X)`
* ```sbaccess``` field was fixed according to ```BusWidth``` --> changed to be writeable

### dm_sba:
* byte-enable according to sbaccess_i was already supported for 8b and 16b
* master_wdata_o was not shifted, so higher byte-enables would write out zeros --> shifted master_wdata_o to be aligned with master_be_o
* sbdata_o was not shifted --> shifted sbdata_o so for read request the requested byte (half-word) is at the LS byte. (according to spec, no need to mask the higher bytes)
* sberror(1) fixed existing code to report unsupported size for any access bigger than BusWidth 
* sberror(2) fixed reported code of unsupported size (sberror=4)
* sberror(3) added misalignment check - if `sbaddress` is not aligned to `sbaccess` (sberror=3) 

I believe this PR should add support for ```sbaccess32``` on BusWidth=64 systems - but I did not test this. 