### PR TITLE
Fix various lint warnings

### DIFF
--- a/debug_rom/debug_rom.sv
+++ b/debug_rom/debug_rom.sv
@@ -23,7 +23,8 @@ module debug_rom (
 
   localparam int unsigned RomSize = 19;
 
-  const logic [RomSize-1:0][63:0] mem = {
+  logic [RomSize-1:0][63:0] mem;
+  assign mem = {
     64'h00000000_7b200073,
     64'h7b202473_7b302573,
     64'h10852423_f1402473,

--- a/debug_rom/debug_rom_one_scratch.sv
+++ b/debug_rom/debug_rom_one_scratch.sv
@@ -23,7 +23,8 @@ module debug_rom_one_scratch (
 
   localparam int unsigned RomSize = 13;
 
-  const logic [RomSize-1:0][63:0] mem = {
+  logic [RomSize-1:0][63:0] mem;
+  assign mem = {
     64'h00000000_7b200073,
     64'h7b202473_10802423,
     64'hf1402473_ab1ff06f,

--- a/debug_rom/gen_rom.py
+++ b/debug_rom/gen_rom.py
@@ -50,7 +50,8 @@ module $filename (
 
   localparam int unsigned RomSize = $size;
 
-  const logic [RomSize-1:0][63:0] mem = {
+  logic [RomSize-1:0][63:0] mem;
+  assign mem = {
 $content
   };
 
@@ -131,4 +132,3 @@ with open(filename + ".sv", "w") as f:
     f.write(license)
     s = Template(module)
     f.write(s.substitute(filename=filename, size=int(len(rom)/8), content=rom_str))
-

--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -336,7 +336,8 @@ module dm_mem #(
     abstract_cmd[0][31:0]  = dm::illegal();
     // load debug module base address into a0, this is shared among all commands
     abstract_cmd[0][63:32] = HasSndScratch ? dm::auipc(5'd10, '0) : dm::nop();
-    abstract_cmd[1][31:0]  = HasSndScratch ? dm::srli(5'd10, 5'd10, 6'd12) : dm::nop(); // clr lowest 12b -> DM base offset
+    // clr lowest 12b -> DM base offset
+    abstract_cmd[1][31:0]  = HasSndScratch ? dm::srli(5'd10, 5'd10, 6'd12) : dm::nop();
     abstract_cmd[1][63:32] = HasSndScratch ? dm::slli(5'd10, 5'd10, 6'd12) : dm::nop();
     abstract_cmd[2][31:0]  = dm::nop();
     abstract_cmd[2][63:32] = dm::nop();
@@ -395,7 +396,9 @@ module dm_mem #(
           end
         end else if (32'(ac_ar.aarsize) < MaxAar && ac_ar.transfer && !ac_ar.write) begin
           // store a0 in dscratch1
-          abstract_cmd[0][31:0]  = HasSndScratch ? dm::csrw(dm::CSR_DSCRATCH1, LoadBaseAddr) : dm::nop();
+          abstract_cmd[0][31:0]  = HasSndScratch ?
+                                   dm::csrw(dm::CSR_DSCRATCH1, LoadBaseAddr) :
+                                   dm::nop();
           // this range is reserved
           if (ac_ar.regno[15:14] != '0) begin
               abstract_cmd[0][31:0] = dm::ebreak(); // we leave asap

--- a/src/dm_obi_top.sv
+++ b/src/dm_obi_top.sv
@@ -61,42 +61,48 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 module dm_obi_top #(
-  parameter int unsigned        IdWidth          = 1,                   // Width of aid/rid
+  parameter int unsigned        IdWidth          = 1,      // Width of aid/rid
   parameter int unsigned        NrHarts          = 1,
   parameter int unsigned        BusWidth         = 32,
-  parameter int unsigned        DmBaseAddress    = 'h1000,              // default to non-zero page
+  parameter int unsigned        DmBaseAddress    = 'h1000, // default to non-zero page
   // Bitmask to select physically available harts for systems
   // that don't use hart numbers in a contiguous fashion.
   parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}}
 ) (
-  input  logic                  clk_i,                                  // clock
-  input  logic                  rst_ni,                                 // asynchronous reset active low, connect PoR here, not the system reset
+  input  logic                  clk_i,           // clock
+  // asynchronous reset active low, connect PoR here, not the system reset
+  input  logic                  rst_ni,
   input  logic                  testmode_i,
-  output logic                  ndmreset_o,                             // non-debug module reset
-  output logic                  dmactive_o,                             // debug module is active
-  output logic [NrHarts-1:0]    debug_req_o,                            // async debug request
-  input  logic [NrHarts-1:0]    unavailable_i,                          // communicate whether the hart is unavailable (e.g.: power down)
-  input  dm::hartinfo_t [NrHarts-1:0] hartinfo_i,
+  output logic                  ndmreset_o,      // non-debug module reset
+  output logic                  dmactive_o,      // debug module is active
+  output logic [NrHarts-1:0]    debug_req_o,     // async debug request
+  // communicate whether the hart is unavailable (e.g.: power down)
+  input  logic [NrHarts-1:0]    unavailable_i,
+  input  dm::hartinfo_t [NrHarts-1:0]  hartinfo_i,
 
   input  logic                  slave_req_i,
-  output logic                  slave_gnt_o,                            // OBI grant for slave_req_i (not present on dm_top)
+  // OBI grant for slave_req_i (not present on dm_top)
+  output logic                  slave_gnt_o,
   input  logic                  slave_we_i,
   input  logic [BusWidth-1:0]   slave_addr_i,
   input  logic [BusWidth/8-1:0] slave_be_i,
   input  logic [BusWidth-1:0]   slave_wdata_i,
-  input  logic [IdWidth-1:0]    slave_aid_i,                            // Address phase transaction identifier (not present on dm_top)
-  output logic                  slave_rvalid_o,                         // OBI rvalid signal (end of response phase for reads/writes) (not present on dm_top)
+  // Address phase transaction identifier (not present on dm_top)
+  input  logic [IdWidth-1:0]    slave_aid_i,
+  // OBI rvalid signal (end of response phase for reads/writes) (not present on dm_top)
+  output logic                  slave_rvalid_o,
   output logic [BusWidth-1:0]   slave_rdata_o,
-  output logic [IdWidth-1:0]    slave_rid_o,                            // Response phase transaction identifier (not present on dm_top)
+  // Response phase transaction identifier (not present on dm_top)
+  output logic [IdWidth-1:0]    slave_rid_o,
 
   output logic                  master_req_o,
-  output logic [BusWidth-1:0]   master_addr_o,                          // Renamed according to OBI spec
+  output logic [BusWidth-1:0]   master_addr_o,   // Renamed according to OBI spec
   output logic                  master_we_o,
   output logic [BusWidth-1:0]   master_wdata_o,
   output logic [BusWidth/8-1:0] master_be_o,
   input  logic                  master_gnt_i,
-  input  logic                  master_rvalid_i,                        // Renamed according to OBI spec
-  input  logic [BusWidth-1:0]   master_rdata_i,                         // Renamed according to OBI spec
+  input  logic                  master_rvalid_i, // Renamed according to OBI spec
+  input  logic [BusWidth-1:0]   master_rdata_i,  // Renamed according to OBI spec
 
   // Connection to DTM - compatible to RocketChip Debug Module
   input  logic                  dmi_rst_ni,
@@ -137,13 +143,13 @@ module dm_obi_top #(
     .slave_rdata_o           ( slave_rdata_o         ),
 
     .master_req_o            ( master_req_o          ),
-    .master_add_o            ( master_addr_o         ),         // Renamed according to OBI spec
+    .master_add_o            ( master_addr_o         ), // Renamed according to OBI spec
     .master_we_o             ( master_we_o           ),
     .master_wdata_o          ( master_wdata_o        ),
     .master_be_o             ( master_be_o           ),
     .master_gnt_i            ( master_gnt_i          ),
-    .master_r_valid_i        ( master_rvalid_i       ),         // Renamed according to OBI spec
-    .master_r_rdata_i        ( master_rdata_i        ),         // Renamed according to OBI spec
+    .master_r_valid_i        ( master_rvalid_i       ), // Renamed according to OBI spec
+    .master_r_rdata_i        ( master_rdata_i        ), // Renamed according to OBI spec
 
     .dmi_rst_ni              ( dmi_rst_ni            ),
     .dmi_req_valid_i         ( dmi_req_valid_i       ),
@@ -165,16 +171,16 @@ module dm_obi_top #(
       slave_rvalid_q   <= 1'b0;
       slave_rid_q      <= 'b0;
     end else begin
-      if (slave_req_i && slave_gnt_o) begin                     // 1 cycle pulse on rvalid for every granted request
+      if (slave_req_i && slave_gnt_o) begin // 1 cycle pulse on rvalid for every granted request
         slave_rvalid_q <= 1'b1;
-        slave_rid_q    <= slave_aid_i;                          // Mirror aid to rid
+        slave_rid_q    <= slave_aid_i;      // Mirror aid to rid
       end else begin
-        slave_rvalid_q <= 1'b0;                                 // rid is don't care if rvalid = 0
+        slave_rvalid_q <= 1'b0;             // rid is don't care if rvalid = 0
       end
     end
   end
 
-  assign slave_gnt_o = 1'b1;                                    // Always receptive to request (slave_req_i)
+  assign slave_gnt_o = 1'b1;                // Always receptive to request (slave_req_i)
   assign slave_rvalid_o = slave_rvalid_q;
   assign slave_rid_o = slave_rid_q;
 

--- a/src/dm_pkg.sv
+++ b/src/dm_pkg.sv
@@ -215,7 +215,7 @@ package dm;
     logic         sbaccess8;
   } sbcs_t;
 
-  localparam logic[1:0] DTM_SUCCESS = 2'h0;
+  localparam logic [1:0] DTM_SUCCESS = 2'h0;
 
   typedef struct packed {
     logic [6:0]  addr;

--- a/src/dm_sba.sv
+++ b/src/dm_sba.sv
@@ -77,7 +77,7 @@ module dm_sba #(
         be_mask[int'({be_idx[$high(be_idx):1], 1'b0}) +: 2] = '1;
       end
       3'b010: begin
-        if (BusWidth == 32'd64) be_mask[int'({be_idx[$high(be_idx)], 2'b0}) +: 4] = '1;
+        if (BusWidth == 32'd64) be_mask[int'({be_idx[$high(be_idx)], 2'h0}) +: 4] = '1;
         else                    be_mask = '1;
       end
       3'b011: be_mask = '1;
@@ -125,7 +125,7 @@ module dm_sba #(
         if (sbdata_valid_o) begin
           state_d = dm::Idle;
           // auto-increment address
-          if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'b1 << sbaccess_i);
+          if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'h1 << sbaccess_i);
         end
       end
 
@@ -133,7 +133,7 @@ module dm_sba #(
         if (sbdata_valid_o) begin
           state_d = dm::Idle;
           // auto-increment address
-          if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'b1 << sbaccess_i);
+          if (sbautoincrement_i) sbaddress_o = sbaddress_i + (32'h1 << sbaccess_i);
         end
       end
 

--- a/tb/boot_rom.sv
+++ b/tb/boot_rom.sv
@@ -20,7 +20,8 @@ module boot_rom (
     localparam int          RomSize    = 2;
     localparam logic [31:0] entry_addr = 32'h1c00_0080;
 
-    const logic [RomSize-1:0][31:0] mem = {
+    logic [RomSize-1:0][31:0] mem;
+    assign mem = {
         dm_tb_pkg::jalr(5'h0, 5'h1, entry_addr[11:0]),
         dm_tb_pkg::lui(5'h1, entry_addr[31:12])
     };


### PR DESCRIPTION
Fix style and width lint warnings emitted by Verible Lint and Verilator
Lint.

This is a rebased version of https://github.com/pulp-platform/riscv-dbg/pull/73 with some smaller additional cleanups.

One slightly more involved change is around `autoexecdata_idx`, which is now the correct width: The signal holds values 0 to 11 for Data0 to Data11, respectively; four bits are enough for that. When used inside the `unique case` statement the value is guaranteed to be a valid data address.

@msfschaffner PTAL