### PR TITLE
Re-order some blocking assignments to avoid a helper variable

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -213,7 +213,6 @@ module dm_csrs #(
   // helper variables
   dm::dm_csr_e dm_csr_addr;
   dm::sbcs_t sbcs;
-  dm::dmcontrol_t dmcontrol;
   dm::abstractcs_t a_abstractcs;
   logic [3:0] autoexecdata_idx; // 0 == Data0 ... 11 == Data11
 
@@ -288,7 +287,6 @@ module dm_csrs #(
 
     // helper variables
     sbcs         = '0;
-    dmcontrol    = '0;
     a_abstractcs = '0;
 
     // reads
@@ -374,12 +372,11 @@ module dm_csrs #(
           end
         end
         dm::DMControl: begin
-          dmcontrol = dm::dmcontrol_t'(dmi_req_i.data);
+          dmcontrol_d = dmi_req_i.data;
           // clear the havreset of the selected hart
-          if (dmcontrol.ackhavereset) begin
+          if (dmcontrol_d.ackhavereset) begin
             havereset_d_aligned[selected_hart] = 1'b0;
           end
-          dmcontrol_d = dmi_req_i.data;
         end
         dm::DMStatus:; // write are ignored to R/O register
         dm::Hartinfo:; // hartinfo is R/O


### PR DESCRIPTION
The code should be equivalent, but no longer needs the "dmcontrol"
helper variable. The advantage of doing it this way is that we then
sidestep some Verilator warnings (since we were ignoring every bit
except one in the helper variable).