### PR TITLE
Functional Resets and Async Reset Glitch Prevention

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ package:
 
 dependencies:
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.3 }
-  common_cells: {git: https://github.com/pulp-platform/common_cells.git, version: 1.21.0}
+  common_cells: {git: https://github.com/pulp-platform/common_cells.git, rev: clearable_cdcs}
 
 sources:
   files:

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ package:
 
 dependencies:
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.3 }
-  common_cells: {git: https://github.com/pulp-platform/common_cells.git, rev: clearable_cdcs}
+  common_cells: {git: "https://github.com/pulp-platform/common_cells.git", version: 1.24.0}
 
 sources:
   files:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add sbaccess8 and sbaccess16 support (#106) [@noytzach](https://github.com/noytzach)
 - Implement SBA bad address error (#12) [@msfchaffner](https://github.com/msfschaffner)
+- Added random reset tests to dmi testbench.
 ### Changed
+- Implement `dmihardreset` functionaliy in `dtmcs` register.
+- `dmi_rst_ni` of `dm_top` is now a synchronous signal. However, `dmi_rst_no` of
+  `dmi_jtag` is glitch-free and asserted during all forms (functional or POR) of
+  resets.
 ### Fixed
 - Fixed documentation (csr)
 - Fixed reset value of sbcs register (#127) [@msfchaffner](https://github.com/msfschaffner)
 - Fixed various ascent lint warnings [@msfchaffner](https://github.com/msfschaffner)
+- Implement proper CDC flushing behavior on functional resets and JTAG resets (asynchronous or TestLogicReset driven).
+- Fix JTAG non-compliance in TestLogicReset state (IR should reset to IDCODE).
 
 ## [0.4.1] - 2021-05-04
 ### Added

--- a/doc/debug-system.md
+++ b/doc/debug-system.md
@@ -485,7 +485,6 @@ default the IR register is 5 bits long, but the implementation is parameterized.
   ) (
   ```
 - `DTMCSR`: RISC-V specific control and status register of the JTAG DMI.
-  Currently `dmihardreset` is not implemented.
 - `DMIACCESS`: Access the debug module's register.
     - `abits+33:34`: Address
     - `33:2`: Data

--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -23,7 +23,8 @@ module dm_csrs #(
   input  logic                              clk_i,           // Clock
   input  logic                              rst_ni,          // Asynchronous reset active low
   input  logic                              testmode_i,
-  input  logic                              dmi_rst_ni,      // Debug Module Intf reset active-low
+  input  logic                              dmi_rst_ni,      // sync. DTM reset,
+                                                             // active-low
   input  logic                              dmi_req_valid_i,
   output logic                              dmi_req_ready_o,
   input  dm::dmi_req_t                      dmi_req_i,
@@ -559,9 +560,10 @@ module dm_csrs #(
     .dtype            ( logic [31:0]         ),
     .DEPTH            ( 2                    )
   ) i_fifo (
-    .clk_i            ( clk_i                ),
-    .rst_ni           ( dmi_rst_ni           ), // reset only when system is re-set
-    .flush_i          ( 1'b0                 ), // we do not need to flush this queue
+    .clk_i,
+    .rst_ni,
+    .flush_i          ( ~dmi_rst_ni          ), // Flush the queue if the DTM is
+                                                // reset
     .testmode_i       ( testmode_i           ),
     .full_o           ( resp_queue_full      ),
     .empty_o          ( resp_queue_empty     ),

--- a/src/dm_top.sv
+++ b/src/dm_top.sv
@@ -57,7 +57,9 @@ module dm_top #(
   input  logic [BusWidth-1:0]   master_r_rdata_i,
 
   // Connection to DTM - compatible to RocketChip Debug Module
-  input  logic                  dmi_rst_ni,
+  input  logic                  dmi_rst_ni, // Synchronous clear request from
+                                            // the DTM to clear the DMI response
+                                            // FIFO.
   input  logic                  dmi_req_valid_i,
   output logic                  dmi_req_ready_o,
   input  dm::dmi_req_t          dmi_req_i,

--- a/src/dmi_cdc.sv
+++ b/src/dmi_cdc.sv
@@ -19,7 +19,7 @@
 module dmi_cdc (
   // JTAG side (master side)
   input  logic             tck_i,
-
+  input  logic             trst_ni,
   input  dm::dmi_req_t     jtag_dmi_req_i,
   output logic             jtag_dmi_ready_o,
   input  logic             jtag_dmi_valid_i,
@@ -47,7 +47,7 @@ module dmi_cdc (
 
 
   cdc_2phase_clearable #(.T(dm::dmi_req_t)) i_cdc_req (
-    .src_rst_ni  ( rst_ni               ),
+    .src_rst_ni  ( trst_ni              ),
     .src_clear_i ( jtag_dmi_cdc_clear_i ),
     .src_clk_i   ( tck_i                ),
     .src_data_i  ( jtag_dmi_req_i       ),
@@ -63,7 +63,7 @@ module dmi_cdc (
     .dst_ready_i ( core_dmi_ready_i     )
   );
 
-  cdc_2phase #(.T(dm::dmi_resp_t)) i_cdc_resp (
+  cdc_2phase_clearable #(.T(dm::dmi_resp_t)) i_cdc_resp (
     .src_rst_ni  ( rst_ni               ),
     .src_clear_i ( 1'b0                 ), // No functional reset from core side
                                            // used (only async ).

--- a/src/dmi_cdc.sv
+++ b/src/dmi_cdc.sv
@@ -50,6 +50,7 @@ module dmi_cdc (
     .src_rst_ni  ( trst_ni              ),
     .src_clear_i ( jtag_dmi_cdc_clear_i ),
     .src_clk_i   ( tck_i                ),
+    .src_clear_pending_o(), // Not used
     .src_data_i  ( jtag_dmi_req_i       ),
     .src_valid_i ( jtag_dmi_valid_i     ),
     .src_ready_o ( jtag_dmi_ready_o     ),
@@ -57,6 +58,7 @@ module dmi_cdc (
     .dst_rst_ni  ( rst_ni               ),
     .dst_clear_i ( 1'b0                 ), // No functional reset from core side
                                            // used (only async).
+    .dst_clear_pending_o(), // Not used
     .dst_clk_i   ( clk_i                ),
     .dst_data_o  ( core_dmi_req_o       ),
     .dst_valid_o ( core_dmi_valid_o     ),
@@ -67,6 +69,7 @@ module dmi_cdc (
     .src_rst_ni  ( rst_ni               ),
     .src_clear_i ( 1'b0                 ), // No functional reset from core side
                                            // used (only async ).
+    .src_clear_pending_o(), // Not used
     .src_clk_i   ( clk_i                ),
     .src_data_i  ( core_dmi_resp_i      ),
     .src_valid_i ( core_dmi_valid_i     ),
@@ -74,6 +77,7 @@ module dmi_cdc (
 
     .dst_rst_ni  ( trst_ni              ),
     .dst_clear_i ( jtag_dmi_cdc_clear_i ),
+    .dst_clear_pending_o(), //Not used
     .dst_clk_i   ( tck_i                ),
     .dst_data_o  ( jtag_dmi_resp_o      ),
     .dst_valid_o ( jtag_dmi_valid_o     ),

--- a/src/dmi_cdc.sv
+++ b/src/dmi_cdc.sv
@@ -48,7 +48,7 @@ module dmi_cdc (
 
   cdc_2phase_clearable #(.T(dm::dmi_req_t)) i_cdc_req (
     .src_rst_ni  ( rst_ni               ),
-    .src_clear_i ( jtag_dmi_cdc_clear_i )
+    .src_clear_i ( jtag_dmi_cdc_clear_i ),
     .src_clk_i   ( tck_i                ),
     .src_data_i  ( jtag_dmi_req_i       ),
     .src_valid_i ( jtag_dmi_valid_i     ),

--- a/src/dmi_cdc.sv
+++ b/src/dmi_cdc.sv
@@ -19,11 +19,13 @@
 module dmi_cdc (
   // JTAG side (master side)
   input  logic             tck_i,
-  input  logic             trst_ni,
 
   input  dm::dmi_req_t     jtag_dmi_req_i,
   output logic             jtag_dmi_ready_o,
   input  logic             jtag_dmi_valid_i,
+  input  logic             jtag_dmi_cdc_clear_i, // Synchronous clear signal.
+                                                 // Triggers reset sequencing
+                                                 // accross CDC
 
   output dm::dmi_resp_t    jtag_dmi_resp_o,
   output logic             jtag_dmi_valid_o,
@@ -42,32 +44,40 @@ module dmi_cdc (
   input  logic             core_dmi_valid_i
 );
 
-  cdc_2phase #(.T(dm::dmi_req_t)) i_cdc_req (
-    .src_rst_ni  ( trst_ni          ),
-    .src_clk_i   ( tck_i            ),
-    .src_data_i  ( jtag_dmi_req_i   ),
-    .src_valid_i ( jtag_dmi_valid_i ),
-    .src_ready_o ( jtag_dmi_ready_o ),
 
-    .dst_rst_ni  ( rst_ni           ),
-    .dst_clk_i   ( clk_i            ),
-    .dst_data_o  ( core_dmi_req_o   ),
-    .dst_valid_o ( core_dmi_valid_o ),
-    .dst_ready_i ( core_dmi_ready_i )
+
+  cdc_2phase_clearable #(.T(dm::dmi_req_t)) i_cdc_req (
+    .src_rst_ni  ( rst_ni               ),
+    .src_clear_i ( jtag_dmi_cdc_clear_i )
+    .src_clk_i   ( tck_i                ),
+    .src_data_i  ( jtag_dmi_req_i       ),
+    .src_valid_i ( jtag_dmi_valid_i     ),
+    .src_ready_o ( jtag_dmi_ready_o     ),
+
+    .dst_rst_ni  ( rst_ni               ),
+    .dst_clear_i ( 1'b0                 ), // No functional reset from core side
+                                           // used (only async).
+    .dst_clk_i   ( clk_i                ),
+    .dst_data_o  ( core_dmi_req_o       ),
+    .dst_valid_o ( core_dmi_valid_o     ),
+    .dst_ready_i ( core_dmi_ready_i     )
   );
 
   cdc_2phase #(.T(dm::dmi_resp_t)) i_cdc_resp (
-    .src_rst_ni  ( rst_ni           ),
-    .src_clk_i   ( clk_i            ),
-    .src_data_i  ( core_dmi_resp_i  ),
-    .src_valid_i ( core_dmi_valid_i ),
-    .src_ready_o ( core_dmi_ready_o ),
+    .src_rst_ni  ( rst_ni               ),
+    .src_clear_i ( 1'b0                 ), // No functional reset from core side
+                                           // used (only async ).
+    .src_clk_i   ( clk_i                ),
+    .src_data_i  ( core_dmi_resp_i      ),
+    .src_valid_i ( core_dmi_valid_i     ),
+    .src_ready_o ( core_dmi_ready_o     ),
 
-    .dst_rst_ni  ( trst_ni          ),
-    .dst_clk_i   ( tck_i            ),
-    .dst_data_o  ( jtag_dmi_resp_o  ),
-    .dst_valid_o ( jtag_dmi_valid_o ),
-    .dst_ready_i ( jtag_dmi_ready_i )
+    .dst_rst_ni  ( trst_ni              ),
+    .dst_clear_i ( jtag_dmi_cdc_clear_i ),
+    .dst_clk_i   ( tck_i                ),
+    .dst_data_o  ( jtag_dmi_resp_o      ),
+    .dst_valid_o ( jtag_dmi_valid_o     ),
+    .dst_ready_i ( jtag_dmi_ready_i     )
   );
 
 endmodule : dmi_cdc

--- a/src/dmi_jtag.sv
+++ b/src/dmi_jtag.sv
@@ -23,7 +23,9 @@ module dmi_jtag #(
   input  logic         rst_ni,     // Asynchronous reset active low
   input  logic         testmode_i,
 
-  output logic         dmi_rst_no, // hard reset
+  // active-low glitch free reset signal. Is asserted for one dmi clock cycle
+  // (clk_i) whenever the dmi_jtag is reset (POR or functional reset).
+  output logic         dmi_rst_no,
   output dm::dmi_req_t dmi_req_o,
   output logic         dmi_req_valid_o,
   input  logic         dmi_req_ready_i,
@@ -98,8 +100,6 @@ module dmi_jtag #(
   // ----------------------------
   // DMI (Debug Module Interface)
   // ----------------------------
-
-  assign dmi_rst_no = dmi_clear;
 
   logic        dmi_select;
   logic        dmi_tdo;
@@ -314,6 +314,7 @@ module dmi_jtag #(
     // core side
     .clk_i,
     .rst_ni,
+    .core_dmi_rst_no      ( dmi_rst_no       ),
     .core_dmi_req_o       ( dmi_req_o        ),
     .core_dmi_valid_o     ( dmi_req_valid_o  ),
     .core_dmi_ready_i     ( dmi_req_ready_i  ),

--- a/src/dmi_jtag.sv
+++ b/src/dmi_jtag.sv
@@ -55,12 +55,13 @@ module dmi_jtag #(
   logic shift;
   logic tdi;
 
-  assign dmi_clear = jtag_dmi_clear || dtmcs_q.dmihardreset;
+  logic dtmcs_select;
+
+  assign dmi_clear = jtag_dmi_clear || (dtmcs_select && update && dtmcs_q.dmihardreset);
 
   // -------------------------------
   // Debug Module Control and Status
   // -------------------------------
-  logic dtmcs_select;
 
   dm::dtmcs_t dtmcs_d, dtmcs_q;
 

--- a/src/dmi_jtag.sv
+++ b/src/dmi_jtag.sv
@@ -145,7 +145,7 @@ module dmi_jtag #(
     dmi_req_valid = 1'b0;
 
     if (dmi_clear) begin
-      state_d   = IDLE;
+      state_d   = Idle;
       data_d    = '0;
       error_d   = DMINoError;
       address_d = '0;

--- a/src/dmi_jtag.sv
+++ b/src/dmi_jtag.sv
@@ -47,11 +47,15 @@ module dmi_jtag #(
   dmi_error_e error_d, error_q;
 
   logic tck;
-  logic trst_n;
+  logic jtag_dmi_clear; // Synchronous reset of DMI triggered by TestLogicReset in
+                        // jtag TAP
+  logic dmi_clear; // Functional (warm) reset of the entire DMI
   logic update;
   logic capture;
   logic shift;
   logic tdi;
+
+  assign dmi_clear = jtag_dmi_clear || dtmcs_q.dmihardreset;
 
   // -------------------------------
   // Debug Module Control and Status
@@ -61,8 +65,7 @@ module dmi_jtag #(
   dm::dtmcs_t dtmcs_d, dtmcs_q;
 
   always_comb begin
-    dtmcs_d  = dtmcs_q;
-
+    dtmcs_d = dtmcs_q;
     if (capture) begin
       if (dtmcs_select) begin
         dtmcs_d  = '{
@@ -83,8 +86,8 @@ module dmi_jtag #(
     end
   end
 
-  always_ff @(posedge tck or negedge trst_n) begin
-    if (!trst_n) begin
+  always_ff @(posedge tck or negedge trst_ni) begin
+    if (!trst_ni) begin
       dtmcs_q <= '0;
     end else begin
       dtmcs_q <= dtmcs_d;
@@ -94,9 +97,8 @@ module dmi_jtag #(
   // ----------------------------
   // DMI (Debug Module Interface)
   // ----------------------------
-  // TODO(zarubaf): Might need to be connected to the `dtmcs_q.dmihardreset`
-  // signal.
-  assign dmi_rst_no = rst_ni;
+
+  assign dmi_rst_no = dmi_clear;
 
   logic        dmi_select;
   logic        dmi_tdo;
@@ -142,79 +144,86 @@ module dmi_jtag #(
 
     dmi_req_valid = 1'b0;
 
-    unique case (state_q)
-      Idle: begin
-        // make sure that no error is sticky
-        if (dmi_select && update && (error_q == DMINoError)) begin
-          // save address and value
-          address_d = dmi.address;
-          data_d = dmi.data;
-          if (dm::dtm_op_e'(dmi.op) == dm::DTM_READ) begin
-            state_d = Read;
-          end else if (dm::dtm_op_e'(dmi.op) == dm::DTM_WRITE) begin
-            state_d = Write;
+    if (dmi_clear) begin
+      state_d   = IDLE;
+      data_d    = '0;
+      error_d   = DMINoError;
+      address_d = '0;
+    end else begin
+      unique case (state_q)
+        Idle: begin
+          // make sure that no error is sticky
+          if (dmi_select && update && (error_q == DMINoError)) begin
+            // save address and value
+            address_d = dmi.address;
+            data_d = dmi.data;
+            if (dm::dtm_op_e'(dmi.op) == dm::DTM_READ) begin
+              state_d = Read;
+            end else if (dm::dtm_op_e'(dmi.op) == dm::DTM_WRITE) begin
+              state_d = Write;
+            end
+            // else this is a nop and we can stay here
           end
-          // else this is a nop and we can stay here
         end
+
+        Read: begin
+          dmi_req_valid = 1'b1;
+          if (dmi_req_ready) begin
+            state_d = WaitReadValid;
+          end
+        end
+
+        WaitReadValid: begin
+          // load data into register and shift out
+          if (dmi_resp_valid) begin
+            data_d = dmi_resp.data;
+            state_d = Idle;
+          end
+        end
+
+        Write: begin
+          dmi_req_valid = 1'b1;
+          // request sent, wait for response before going back to idle
+          if (dmi_req_ready) begin
+            state_d = WaitWriteValid;
+          end
+        end
+
+        WaitWriteValid: begin
+          // got a valid answer go back to idle
+          if (dmi_resp_valid) begin
+            state_d = Idle;
+          end
+        end
+
+        default: begin
+          // just wait for idle here
+          if (dmi_resp_valid) begin
+            state_d = Idle;
+          end
+        end
+      endcase
+
+      // update means we got another request but we didn't finish
+      // the one in progress, this state is sticky
+      if (update && state_q != Idle) begin
+        error_dmi_busy = 1'b1;
       end
 
-      Read: begin
-        dmi_req_valid = 1'b1;
-        if (dmi_req_ready) begin
-          state_d = WaitReadValid;
-        end
+      // if capture goes high while we are in the read state
+      // or in the corresponding wait state we are not giving back a valid word
+      // -> throw an error
+      if (capture && state_q inside {Read, WaitReadValid}) begin
+        error_dmi_busy = 1'b1;
       end
 
-      WaitReadValid: begin
-        // load data into register and shift out
-        if (dmi_resp_valid) begin
-          data_d = dmi_resp.data;
-          state_d = Idle;
-        end
+      if (error_dmi_busy) begin
+        error_d = DMIBusy;
       end
-
-      Write: begin
-        dmi_req_valid = 1'b1;
-        // request sent, wait for response before going back to idle
-        if (dmi_req_ready) begin
-          state_d = WaitWriteValid;
-        end
+      // clear sticky error flag
+      if (update && dtmcs_q.dmireset && dtmcs_select) begin
+        error_d = DMINoError;
       end
-
-      WaitWriteValid: begin
-        // got a valid answer go back to idle
-        if (dmi_resp_valid) begin
-          state_d = Idle;
-        end
-      end
-
-      default: begin
-        // just wait for idle here
-        if (dmi_resp_valid) begin
-          state_d = Idle;
-        end
-      end
-    endcase
-
-    // update means we got another request but we didn't finish
-    // the one in progress, this state is sticky
-    if (update && state_q != Idle) begin
-      error_dmi_busy = 1'b1;
-    end
-
-    // if capture goes high while we are in the read state
-    // or in the corresponding wait state we are not giving back a valid word
-    // -> throw an error
-    if (capture && state_q inside {Read, WaitReadValid}) begin
-      error_dmi_busy = 1'b1;
-    end
-
-    if (error_dmi_busy) begin
-      error_d = DMIBusy;
-    end
-    // clear sticky error flag
-    if (update && dtmcs_q.dmireset && dtmcs_select) begin
-      error_d = DMINoError;
     end
   end
 
@@ -223,27 +232,30 @@ module dmi_jtag #(
 
   always_comb begin : p_shift
     dr_d    = dr_q;
-
-    if (capture) begin
-      if (dmi_select) begin
-        if (error_q == DMINoError && !error_dmi_busy) begin
-          dr_d = {address_q, data_q, DMINoError};
-        // DMI was busy, report an error
-        end else if (error_q == DMIBusy || error_dmi_busy) begin
-          dr_d = {address_q, data_q, DMIBusy};
+    if (dmi_clear) begin
+      dr_d = '0;
+    end else begin
+      if (capture) begin
+        if (dmi_select) begin
+          if (error_q == DMINoError && !error_dmi_busy) begin
+            dr_d = {address_q, data_q, DMINoError};
+            // DMI was busy, report an error
+          end else if (error_q == DMIBusy || error_dmi_busy) begin
+            dr_d = {address_q, data_q, DMIBusy};
+          end
         end
       end
-    end
 
-    if (shift) begin
-      if (dmi_select) begin
-        dr_d = {tdi, dr_q[$bits(dr_q)-1:1]};
+      if (shift) begin
+        if (dmi_select) begin
+          dr_d = {tdi, dr_q[$bits(dr_q)-1:1]};
+        end
       end
     end
   end
 
-  always_ff @(posedge tck or negedge trst_n) begin
-    if (!trst_n) begin
+  always_ff @(posedge tck or negedge trst_ni) begin
+    if (!trst_ni) begin
       dr_q      <= '0;
       state_q   <= Idle;
       address_q <= '0;
@@ -273,7 +285,7 @@ module dmi_jtag #(
     .tdo_oe_o,
     .testmode_i,
     .tck_o          ( tck              ),
-    .trst_no        ( trst_n           ),
+    .dmi_clear_o    ( jtag_dmi_clear   ),
     .update_o       ( update           ),
     .capture_o      ( capture          ),
     .shift_o        ( shift            ),
@@ -289,23 +301,24 @@ module dmi_jtag #(
   // ---------
   dmi_cdc i_dmi_cdc (
     // JTAG side (master side)
-    .tck_i             ( tck              ),
-    .trst_ni           ( trst_n           ),
-    .jtag_dmi_req_i    ( dmi_req          ),
-    .jtag_dmi_ready_o  ( dmi_req_ready    ),
-    .jtag_dmi_valid_i  ( dmi_req_valid    ),
-    .jtag_dmi_resp_o   ( dmi_resp         ),
-    .jtag_dmi_valid_o  ( dmi_resp_valid   ),
-    .jtag_dmi_ready_i  ( dmi_resp_ready   ),
+    .tck_i                ( tck              ),
+    .trst_ni              ( trst_ni          ),
+    .jtag_dmi_cdc_clear_i ( dmi_clear        ),
+    .jtag_dmi_req_i       ( dmi_req          ),
+    .jtag_dmi_ready_o     ( dmi_req_ready    ),
+    .jtag_dmi_valid_i     ( dmi_req_valid    ),
+    .jtag_dmi_resp_o      ( dmi_resp         ),
+    .jtag_dmi_valid_o     ( dmi_resp_valid   ),
+    .jtag_dmi_ready_i     ( dmi_resp_ready   ),
     // core side
     .clk_i,
     .rst_ni,
-    .core_dmi_req_o    ( dmi_req_o        ),
-    .core_dmi_valid_o  ( dmi_req_valid_o  ),
-    .core_dmi_ready_i  ( dmi_req_ready_i  ),
-    .core_dmi_resp_i   ( dmi_resp_i       ),
-    .core_dmi_ready_o  ( dmi_resp_ready_o ),
-    .core_dmi_valid_i  ( dmi_resp_valid_i )
+    .core_dmi_req_o       ( dmi_req_o        ),
+    .core_dmi_valid_o     ( dmi_req_valid_o  ),
+    .core_dmi_ready_i     ( dmi_req_ready_i  ),
+    .core_dmi_resp_i      ( dmi_resp_i       ),
+    .core_dmi_ready_o     ( dmi_resp_ready_o ),
+    .core_dmi_valid_i     ( dmi_resp_valid_i )
   );
 
 endmodule : dmi_jtag

--- a/src/dmi_jtag_tap.sv
+++ b/src/dmi_jtag_tap.sv
@@ -34,7 +34,8 @@ module dmi_jtag_tap #(
   input  logic        testmode_i,
   // JTAG is interested in writing the DTM CSR register
   output logic        tck_o,
-  output logic        trst_no,
+  // Synchronous reset of the dmi module triggered by JTAG TAP
+  output logic        dmi_clear_o,
   output logic        update_o,
   output logic        capture_o,
   output logic        shift_o,
@@ -202,7 +203,7 @@ module dmi_jtag_tap #(
   // Determination of next state; purely combinatorial
   always_comb begin : p_tap_fsm
 
-    trst_no            = trst_ni;
+    dmi_clear_o        = 1'b0;
 
     capture_dr         = 1'b0;
     shift_dr           = 1'b0;
@@ -216,7 +217,7 @@ module dmi_jtag_tap #(
     unique case (tap_state_q)
       TestLogicReset: begin
         tap_state_d = (tms_i) ? TestLogicReset : RunTestIdle;
-        trst_no = 1'b1;
+        dmi_clear_o = 1'b1;
       end
       RunTestIdle: begin
         tap_state_d = (tms_i) ? SelectDrScan : RunTestIdle;

--- a/src/dmi_jtag_tap.sv
+++ b/src/dmi_jtag_tap.sv
@@ -73,7 +73,7 @@ module dmi_jtag_tap #(
   logic [IrLength-1:0]  jtag_ir_shift_d, jtag_ir_shift_q;
   // IR register -> this gets captured from shift register upon update_ir
   ir_reg_e              jtag_ir_d, jtag_ir_q;
-  logic capture_ir, shift_ir, update_ir; // pause_ir
+  logic capture_ir, shift_ir, update_ir, test_logic_reset; // pause_ir
 
   always_comb begin : p_jtag
     jtag_ir_shift_d = jtag_ir_shift_q;
@@ -92,6 +92,11 @@ module dmi_jtag_tap #(
     // update IR register
     if (update_ir) begin
       jtag_ir_d = ir_reg_e'(jtag_ir_shift_q);
+    end
+
+    // According to JTAG spec we have to reset the IR to IDCODE in test_logic_reset
+    if (test_logic_reset) begin
+      jtag_ir_d = IDCODE;
     end
   end
 
@@ -203,7 +208,7 @@ module dmi_jtag_tap #(
   // Determination of next state; purely combinatorial
   always_comb begin : p_tap_fsm
 
-    dmi_clear_o        = 1'b0;
+    test_logic_reset   = 1'b0;
 
     capture_dr         = 1'b0;
     shift_dr           = 1'b0;
@@ -217,7 +222,7 @@ module dmi_jtag_tap #(
     unique case (tap_state_q)
       TestLogicReset: begin
         tap_state_d = (tms_i) ? TestLogicReset : RunTestIdle;
-        dmi_clear_o = 1'b1;
+        test_logic_reset = 1'b1;
       end
       RunTestIdle: begin
         tap_state_d = (tms_i) ? SelectDrScan : RunTestIdle;
@@ -308,5 +313,7 @@ module dmi_jtag_tap #(
   assign update_o = update_dr;
   assign shift_o = shift_dr;
   assign capture_o = capture_dr;
+  assign dmi_clear_o = test_logic_reset;
+
 
 endmodule : dmi_jtag_tap

--- a/tb/jtag_dmi/jtag_test.sv
+++ b/tb/jtag_dmi/jtag_test.sv
@@ -43,6 +43,9 @@ package jtag_test;
       repeat (6) clock();
       jtag.tms <= #TA 0;
       clock();
+      // After softreset the IR should be reset to IDCODE so we have to mirror
+      // this in our internal state.
+      this.ir_select = 'h1;
     endtask
 
     // Set IR, but only if it needs to be set.

--- a/tb/jtag_dmi/jtag_test.sv
+++ b/tb/jtag_dmi/jtag_test.sv
@@ -33,6 +33,7 @@ package jtag_test;
       jtag.trst_n <= #TA 0;
       repeat (2) clock();
       jtag.trst_n <= #TA 1;
+      this.ir_select = 'h1;
       clock();
     endtask
 

--- a/tb/remote_bitbang/remote_bitbang.c
+++ b/tb/remote_bitbang/remote_bitbang.c
@@ -115,7 +115,7 @@ void rbs_tick(unsigned char *jtag_tck, unsigned char *jtag_tms,
 
 void rbs_reset()
 {
-    // trstn = 0;
+    trstn = 0;
 }
 
 void rbs_set_pins(char _tck, char _tms, char _tdi)


### PR DESCRIPTION
Fixes #120 and adds support for dtmcs.dmihardreset. 

The asynchronous reset now is only controlled by the asynchronous active-low `jtag_trst` signal. All functional reset sources (JTAG Softreset through `TestLogicReset` state or `dtmcs.dmihardreset`) trigger a synchronous reset which is then handled by the new, clearable CDC module that synchronizes the clear request into the other clock-domain. I modified the existing dmi TB to issue random resets (synchronous and asynchronous) during the dmi transactions to verify proper functionality. To that end this PR fixes a small bug in the JTAG verification IP (ir_select was not reset during the jtag.master_reset() task).   

The PR depends on an outstanding [PR](https://github.com/pulp-platform/common_cells/pull/126) in the `pulp-platform/common_cells` repository that adds new CDC IPs with support for one-sided asynchronous resets. Once the `common_cells` PR is merged, I will update the bender dependency pointer in this PR accordingly.
