### PR TITLE
[dm_csrs] Correct reset value of sbcs register

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -584,7 +584,7 @@ module dm_csrs #(
       abstractauto_q <= '0;
       progbuf_q      <= '0;
       data_q         <= '0;
-      sbcs_q         <= '0;
+      sbcs_q         <= '{default: '0,  sbaccess: 3'd2};
       sbaddr_q       <= '0;
       sbdata_q       <= '0;
       havereset_q    <= '1;
@@ -612,7 +612,7 @@ module dm_csrs #(
         abstractauto_q               <= '0;
         progbuf_q                    <= '0;
         data_q                       <= '0;
-        sbcs_q                       <= '0;
+        sbcs_q                       <= '{default: '0,  sbaccess: 3'd2};
         sbaddr_q                     <= '0;
         sbdata_q                     <= '0;
       end else begin


### PR DESCRIPTION
Per the [spec](https://raw.githubusercontent.com/riscv/riscv-debug-spec/master/riscv-debug-stable.pdf) on page 42, this field is supposed to be 2 after reset.

Signed-off-by: Michael Schaffner <msf@google.com>