### PR TITLE
Fix remote_bitbang r/s/t/u-reset command implementations.

### DIFF
--- a/tb/remote_bitbang/remote_bitbang.c
+++ b/tb/remote_bitbang/remote_bitbang.c
@@ -13,6 +13,24 @@
 
 #include "remote_bitbang.h"
 
+//Public globals, declared in remote_bitbang.h
+
+int rbs_err;
+
+unsigned char tck;
+unsigned char tms;
+unsigned char tdi;
+unsigned char trstn;
+unsigned char tdo;
+unsigned char quit;
+
+int socket_fd;
+int client_fd;
+
+//static const ssize_t buf_size = 64 * 1024;
+char recv_buf[64 * 1024];
+ssize_t recv_start, recv_end;
+
 int rbs_init(uint16_t port)
 {
     socket_fd  = 0;
@@ -118,6 +136,11 @@ void rbs_reset()
     trstn = 0;
 }
 
+void rbs_set()
+{
+    trstn = 1;
+}
+
 void rbs_set_pins(char _tck, char _tms, char _tdi)
 {
     tck = _tck;
@@ -170,24 +193,23 @@ void rbs_execute_command()
     case 'r':
         if (VERBOSE)
             fprintf(stderr, "r-reset\n");
-        rbs_reset();
-        break; // This is wrong. 'r' has other bits that indicated TRST and
-               // SRST.
+        rbs_set(); //r-reset command deasserts TRST. See: openocd/blob/master/doc/manual/jtag/drivers/remote_bitbang.txt
+        break; 
     case 's':
         if (VERBOSE)
             fprintf(stderr, "s-reset\n");
-        rbs_reset();
-        break; // This is wrong.
+        rbs_set(); //s-reset command deasserts TRST. See: openocd/blob/master/doc/manual/jtag/drivers/remote_bitbang.txt
+        break;
     case 't':
         if (VERBOSE)
             fprintf(stderr, "t-reset\n");
-        rbs_reset();
-        break; // This is wrong.
+        rbs_reset(); //t-reset command asserts TRST. See: openocd/blob/master/doc/manual/jtag/drivers/remote_bitbang.txt
+        break;
     case 'u':
         if (VERBOSE)
             fprintf(stderr, "u-reset\n");
-        rbs_reset();
-        break; // This is wrong.
+        rbs_reset(); //u-reset command asserts TRST. See: openocd/blob/master/doc/manual/jtag/drivers/remote_bitbang.txt
+        break;
     case '0':
         if (VERBOSE)
             fprintf(stderr, "Write 0 0 0\n");

--- a/tb/remote_bitbang/remote_bitbang.h
+++ b/tb/remote_bitbang/remote_bitbang.h
@@ -8,21 +8,21 @@
 
 #define VERBOSE 0
 
-int rbs_err;
+extern int rbs_err;
 
-unsigned char tck;
-unsigned char tms;
-unsigned char tdi;
-unsigned char trstn;
-unsigned char tdo;
-unsigned char quit;
+extern unsigned char tck;
+extern unsigned char tms;
+extern unsigned char tdi;
+extern unsigned char trstn;
+extern unsigned char tdo;
+extern unsigned char quit;
 
-int socket_fd;
-int client_fd;
+extern int socket_fd;
+extern int client_fd;
 
-static const ssize_t buf_size = 64 * 1024;
-char recv_buf[64 * 1024];
-ssize_t recv_start, recv_end;
+//static const ssize_t buf_size = 64 * 1024;
+extern char recv_buf[64 * 1024];
+extern ssize_t recv_start, recv_end;
 
 // Create a new server, listening for connections from localhost on the given
 // port.
@@ -44,8 +44,8 @@ void rbs_accept();
 // simulation to run.
 void rbs_execute_command();
 
-// Reset. Currently does nothing.
-void rbs_reset();
+void rbs_reset(); //Assert TRST
+void rbs_set(); //Deassert TRST
 
 void rbs_set_pins(char _tck, char _tms, char _tdi);
 


### PR DESCRIPTION
During bring-up of riscv-dbg on my Verilator testbench I found that TRST was asserted after running  the dm_debug.cfg openocd script.
A bit of investigation showed that TRST got asserted by the r-reset implementation in remote_bitbang.c.
According to the remote [bitbang spec](https://github.com/openocd-org/openocd/blob/master/doc/manual/jtag/drivers/remote_bitbang.txt), r-reset should _deassert_ TRST:

> reset trst srst
> 	Set the value of trst, srst.

> r - Reset 0 0

Similarly, s-reset should also deassert TRST, while t- and u-reset should assert TRST:

> s - Reset 0 1
> t - Reset 1 0
> u - Reset 1 1

As an aside, it's bad form to define globals in .h files. Declarations should go in the .h file, definition in the .C file. That change is also included in the pull request. Sorry for not splitting this into two commits.
