### PR TITLE
jtag_test: Add read_dmi_exp_backoff() and sba_read_double() functions

### DIFF
--- a/src/dm_pkg.sv
+++ b/src/dm_pkg.sv
@@ -197,6 +197,12 @@ package dm;
     DTM_WRITE = 2'h2
   } dtm_op_e;
 
+  typedef enum logic [1:0] {
+    DTM_SUCCESS = 2'h0,
+    DTM_ERR     = 2'h2,
+    DTM_BUSY    = 2'h3
+  } dtm_op_status_e;
+
   typedef struct packed {
     logic [31:29] sbversion;
     logic [28:23] zero0;
@@ -214,8 +220,6 @@ package dm;
     logic         sbaccess16;
     logic         sbaccess8;
   } sbcs_t;
-
-  localparam logic [1:0] DTM_SUCCESS = 2'h0;
 
   typedef struct packed {
     logic [6:0]  addr;


### PR DESCRIPTION
Provides a more robust alternative to `read_dmi()`, which does not rely
on a fixed delay, but rather calls `read_dmi()` until the read is successful
and automatically adjusts the delay with an exponential backoff scheme.