### PR TITLE
Fix DMI response when command or SBA are busy

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -345,6 +345,7 @@ module dm_csrs #(
           // access while the SBA was busy
           if (sbbusy_i || sbcs_q.sbbusyerror) begin
             sbcs_d.sbbusyerror = 1'b1;
+            resp_queue_inp.resp = dm::DTM_BUSY;
           end else begin
             sbdata_read_valid_o = (sbcs_q.sberror == '0);
             resp_queue_inp.data = sbdata_q[31:0];
@@ -354,6 +355,7 @@ module dm_csrs #(
           // access while the SBA was busy
           if (sbbusy_i || sbcs_q.sbbusyerror) begin
             sbcs_d.sbbusyerror = 1'b1;
+            resp_queue_inp.resp = dm::DTM_BUSY;
           end else begin
             resp_queue_inp.data = sbdata_q[63:32];
           end
@@ -455,6 +457,7 @@ module dm_csrs #(
           // access while the SBA was busy
           if (sbbusy_i) begin
             sbcs_d.sbbusyerror = 1'b1;
+            resp_queue_inp.resp = dm::DTM_BUSY;
           end else begin
             sbcs = dm::sbcs_t'(dmi_req_i.data);
             sbcs_d = sbcs;
@@ -467,6 +470,7 @@ module dm_csrs #(
           // access while the SBA was busy
           if (sbbusy_i || sbcs_q.sbbusyerror) begin
             sbcs_d.sbbusyerror = 1'b1;
+            resp_queue_inp.resp = dm::DTM_BUSY;
           end else begin
             sbaddr_d[31:0] = dmi_req_i.data;
             sbaddress_write_valid_o = (sbcs_q.sberror == '0);
@@ -476,6 +480,7 @@ module dm_csrs #(
           // access while the SBA was busy
           if (sbbusy_i || sbcs_q.sbbusyerror) begin
             sbcs_d.sbbusyerror = 1'b1;
+            resp_queue_inp.resp = dm::DTM_BUSY;
           end else begin
             sbaddr_d[63:32] = dmi_req_i.data;
           end
@@ -484,6 +489,7 @@ module dm_csrs #(
           // access while the SBA was busy
           if (sbbusy_i || sbcs_q.sbbusyerror) begin
            sbcs_d.sbbusyerror = 1'b1;
+           resp_queue_inp.resp = dm::DTM_BUSY;
           end else begin
             sbdata_d[31:0] = dmi_req_i.data;
             sbdata_write_valid_o = (sbcs_q.sberror == '0);
@@ -493,6 +499,7 @@ module dm_csrs #(
           // access while the SBA was busy
           if (sbbusy_i || sbcs_q.sbbusyerror) begin
            sbcs_d.sbbusyerror = 1'b1;
+           resp_queue_inp.resp = dm::DTM_BUSY;
           end else begin
             sbdata_d[63:32] = dmi_req_i.data;
           end

--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -90,7 +90,6 @@ module dm_csrs #(
   logic        resp_queue_empty;
   logic        resp_queue_push;
   logic        resp_queue_pop;
-  logic [31:0] resp_queue_data;
 
   localparam dm::dm_csr_e DataEnd = dm::dm_csr_e'(dm::Data0 + {4'h0, dm::DataCount} - 8'h1);
   localparam dm::dm_csr_e ProgBufEnd = dm::dm_csr_e'(dm::ProgBuf0 + {4'h0, dm::ProgBufSize} - 8'h1);
@@ -179,8 +178,8 @@ module dm_csrs #(
 
   logic [HartSelLen-1:0] selected_hart;
 
-  // a successful response returns zero
-  assign dmi_resp_o.resp = dm::DTM_SUCCESS;
+  dm::dmi_resp_t resp_queue_inp;
+
   assign dmi_resp_valid_o     = ~resp_queue_empty;
   assign dmi_req_ready_o      = ~resp_queue_full;
   assign resp_queue_push      = dmi_req_valid_i & dmi_req_ready_o;
@@ -279,7 +278,8 @@ module dm_csrs #(
     sbaddr_d            = 64'(sbaddress_i);
     sbdata_d            = sbdata_q;
 
-    resp_queue_data         = 32'h0;
+    resp_queue_inp.data     = 32'h0;
+    resp_queue_inp.resp     = dm::DTM_SUCCESS;
     cmd_valid_d             = 1'b0;
     sbaddress_write_valid_o = 1'b0;
     sbdata_read_valid_o     = 1'b0;
@@ -294,7 +294,7 @@ module dm_csrs #(
     if (dmi_req_ready_o && dmi_req_valid_i && dtm_op == dm::DTM_READ) begin
       unique case (dm_csr_addr) inside
         [(dm::Data0):DataEnd]: begin
-          resp_queue_data = data_q[$clog2(dm::DataCount)'(autoexecdata_idx)];
+          resp_queue_inp.data = data_q[$clog2(dm::DataCount)'(autoexecdata_idx)];
           if (!cmdbusy_i) begin
             // check whether we need to re-execute the command (just give a cmd_valid)
             cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
@@ -303,15 +303,15 @@ module dm_csrs #(
             cmderr_d = dm::CmdErrBusy;
           end
         end
-        dm::DMControl:    resp_queue_data = dmcontrol_q;
-        dm::DMStatus:     resp_queue_data = dmstatus;
-        dm::Hartinfo:     resp_queue_data = hartinfo_aligned[selected_hart];
-        dm::AbstractCS:   resp_queue_data = abstractcs;
-        dm::AbstractAuto: resp_queue_data = abstractauto_q;
+        dm::DMControl:    resp_queue_inp.data = dmcontrol_q;
+        dm::DMStatus:     resp_queue_inp.data = dmstatus;
+        dm::Hartinfo:     resp_queue_inp.data = hartinfo_aligned[selected_hart];
+        dm::AbstractCS:   resp_queue_inp.data = abstractcs;
+        dm::AbstractAuto: resp_queue_inp.data = abstractauto_q;
         // command is read-only
-        dm::Command:    resp_queue_data = '0;
+        dm::Command:    resp_queue_inp.data = '0;
         [(dm::ProgBuf0):ProgBufEnd]: begin
-          resp_queue_data = progbuf_q[dmi_req_i.addr[$clog2(dm::ProgBufSize)-1:0]];
+          resp_queue_inp.data = progbuf_q[dmi_req_i.addr[$clog2(dm::ProgBufSize)-1:0]];
           if (!cmdbusy_i) begin
             // check whether we need to re-execute the command (just give a cmd_valid)
             // range of autoexecprogbuf is 31:16
@@ -322,18 +322,18 @@ module dm_csrs #(
             cmderr_d = dm::CmdErrBusy;
           end
         end
-        dm::HaltSum0: resp_queue_data = haltsum0;
-        dm::HaltSum1: resp_queue_data = haltsum1;
-        dm::HaltSum2: resp_queue_data = haltsum2;
-        dm::HaltSum3: resp_queue_data = haltsum3;
+        dm::HaltSum0: resp_queue_inp.data = haltsum0;
+        dm::HaltSum1: resp_queue_inp.data = haltsum1;
+        dm::HaltSum2: resp_queue_inp.data = haltsum2;
+        dm::HaltSum3: resp_queue_inp.data = haltsum3;
         dm::SBCS: begin
-          resp_queue_data = sbcs_q;
+          resp_queue_inp.data = sbcs_q;
         end
         dm::SBAddress0: begin
-          resp_queue_data = sbaddr_q[31:0];
+          resp_queue_inp.data = sbaddr_q[31:0];
         end
         dm::SBAddress1: begin
-          resp_queue_data = sbaddr_q[63:32];
+          resp_queue_inp.data = sbaddr_q[63:32];
         end
         dm::SBData0: begin
           // access while the SBA was busy
@@ -341,7 +341,7 @@ module dm_csrs #(
             sbcs_d.sbbusyerror = 1'b1;
           end else begin
             sbdata_read_valid_o = (sbcs_q.sberror == '0);
-            resp_queue_data = sbdata_q[31:0];
+            resp_queue_inp.data = sbdata_q[31:0];
           end
         end
         dm::SBData1: begin
@@ -349,7 +349,7 @@ module dm_csrs #(
           if (sbbusy_i || sbcs_q.sbbusyerror) begin
             sbcs_d.sbbusyerror = 1'b1;
           end else begin
-            resp_queue_data = sbdata_q[63:32];
+            resp_queue_inp.data = sbdata_q[63:32];
           end
         end
         default:;
@@ -557,8 +557,8 @@ module dm_csrs #(
 
   // response FIFO
   fifo_v2 #(
-    .dtype            ( logic [31:0]         ),
-    .DEPTH            ( 2                    )
+    .dtype            ( logic [$bits(dmi_resp_o)-1:0] ),
+    .DEPTH            ( 2                             )
   ) i_fifo (
     .clk_i,
     .rst_ni,
@@ -569,9 +569,9 @@ module dm_csrs #(
     .empty_o          ( resp_queue_empty     ),
     .alm_full_o       (                      ),
     .alm_empty_o      (                      ),
-    .data_i           ( resp_queue_data      ),
+    .data_i           ( resp_queue_inp       ),
     .push_i           ( resp_queue_push      ),
-    .data_o           ( dmi_resp_o.data      ),
+    .data_o           ( dmi_resp_o           ),
     .pop_i            ( resp_queue_pop       )
   );
 

--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -299,8 +299,11 @@ module dm_csrs #(
             // check whether we need to re-execute the command (just give a cmd_valid)
             cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
           // An abstract command was executing while one of the data registers was read
-          end else if (cmderr_q == dm::CmdErrNone) begin
-            cmderr_d = dm::CmdErrBusy;
+          end else begin
+            resp_queue_inp.resp = dm::DTM_BUSY;
+            if (cmderr_q == dm::CmdErrNone) begin
+              cmderr_d = dm::CmdErrBusy;
+            end
           end
         end
         dm::DMControl:    resp_queue_inp.data = dmcontrol_q;
@@ -318,8 +321,11 @@ module dm_csrs #(
             cmd_valid_d = abstractauto_q.autoexecprogbuf[{1'b1, dmi_req_i.addr[3:0]}];
 
           // An abstract command was executing while one of the progbuf registers was read
-          end else if (cmderr_q == dm::CmdErrNone) begin
-            cmderr_d = dm::CmdErrBusy;
+          end else begin
+            resp_queue_inp.resp = dm::DTM_BUSY;
+            if (cmderr_q == dm::CmdErrNone) begin
+              cmderr_d = dm::CmdErrBusy;
+            end
           end
         end
         dm::HaltSum0: resp_queue_inp.data = haltsum0;
@@ -367,8 +373,11 @@ module dm_csrs #(
               // check whether we need to re-execute the command (just give a cmd_valid)
               cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
             //An abstract command was executing while one of the data registers was written
-            end else if (cmderr_q == dm::CmdErrNone) begin
-              cmderr_d = dm::CmdErrBusy;
+            end else begin
+              resp_queue_inp.resp = dm::DTM_BUSY;
+              if (cmderr_q == dm::CmdErrNone) begin
+                cmderr_d = dm::CmdErrBusy;
+              end
             end
           end
         end
@@ -391,8 +400,11 @@ module dm_csrs #(
           // reads during abstract command execution are not allowed
           if (!cmdbusy_i) begin
             cmderr_d = dm::cmderr_e'(~a_abstractcs.cmderr & cmderr_q);
-          end else if (cmderr_q == dm::CmdErrNone) begin
-            cmderr_d = dm::CmdErrBusy;
+          end else begin
+            resp_queue_inp.resp = dm::DTM_BUSY;
+            if (cmderr_q == dm::CmdErrNone) begin
+              cmderr_d = dm::CmdErrBusy;
+            end
           end
         end
         dm::Command: begin
@@ -402,8 +414,11 @@ module dm_csrs #(
             command_d = dm::command_t'(dmi_req_i.data);
           // if there was an attempted to write during a busy execution
           // and the cmderror field is zero set the busy error
-          end else if (cmderr_q == dm::CmdErrNone) begin
-            cmderr_d = dm::CmdErrBusy;
+          end else begin
+            resp_queue_inp.resp = dm::DTM_BUSY;
+            if (cmderr_q == dm::CmdErrNone) begin
+              cmderr_d = dm::CmdErrBusy;
+            end
           end
         end
         dm::AbstractAuto: begin
@@ -412,8 +427,11 @@ module dm_csrs #(
             abstractauto_d                 = 32'h0;
             abstractauto_d.autoexecdata    = 12'(dmi_req_i.data[dm::DataCount-1:0]);
             abstractauto_d.autoexecprogbuf = 16'(dmi_req_i.data[dm::ProgBufSize-1+16:16]);
-          end else if (cmderr_q == dm::CmdErrNone) begin
-            cmderr_d = dm::CmdErrBusy;
+          end else begin
+            resp_queue_inp.resp = dm::DTM_BUSY;
+            if (cmderr_q == dm::CmdErrNone) begin
+              cmderr_d = dm::CmdErrBusy;
+            end
           end
         end
         [(dm::ProgBuf0):ProgBufEnd]: begin
@@ -426,8 +444,11 @@ module dm_csrs #(
             // range of autoexecprogbuf is 31:16
             cmd_valid_d = abstractauto_q.autoexecprogbuf[{1'b1, dmi_req_i.addr[3:0]}];
           //An abstract command was executing while one of the progbuf registers was written
-          end else if (cmderr_q == dm::CmdErrNone) begin
-            cmderr_d = dm::CmdErrBusy;
+          end else begin
+            resp_queue_inp.resp = dm::DTM_BUSY;
+            if (cmderr_q == dm::CmdErrNone) begin
+              cmderr_d = dm::CmdErrBusy;
+            end
           end
         end
         dm::SBCS: begin

--- a/src/dmi_jtag.sv
+++ b/src/dmi_jtag.sv
@@ -223,7 +223,7 @@ module dmi_jtag #(
         error_dmi_busy = 1'b1;
       end
 
-      if (error_dmi_busy) begin
+      if (error_dmi_busy && error_q == DMINoError) begin
         error_d = DMIBusy;
       end
       // clear sticky error flag

--- a/src/dmi_jtag.sv
+++ b/src/dmi_jtag.sv
@@ -134,9 +134,11 @@ module dmi_jtag #(
   assign dmi_resp_ready = 1'b1;
 
   logic error_dmi_busy;
+  logic error_dmi_op_failed;
 
   always_comb begin : p_fsm
     error_dmi_busy = 1'b0;
+    error_dmi_op_failed = 1'b0;
     // default assignments
     state_d   = state_q;
     address_d = address_q;
@@ -226,6 +228,11 @@ module dmi_jtag #(
       if (error_dmi_busy && error_q == DMINoError) begin
         error_d = DMIBusy;
       end
+
+      if (error_dmi_op_failed && error_q == DMINoError) begin
+        error_d = DMIOPFailed;
+      end
+
       // clear sticky error flag
       if (update && dtmcs_q.dmireset && dtmcs_select) begin
         error_d = DMINoError;

--- a/src/dmi_jtag.sv
+++ b/src/dmi_jtag.sv
@@ -177,7 +177,12 @@ module dmi_jtag #(
         WaitReadValid: begin
           // load data into register and shift out
           if (dmi_resp_valid) begin
-            data_d = dmi_resp.data;
+            unique case (dmi_resp.resp)
+              dm::DTM_SUCCESS: data_d = dmi_resp.data;
+              dm::DTM_ERR:     data_d = 32'hDEAD_BEEF;
+              dm::DTM_BUSY:    data_d = 32'hB051_B051;
+              default:         data_d = 32'hBAAD_C0DE;
+            endcase
             state_d = Idle;
           end
         end


### PR DESCRIPTION
The [RISC-V External Debug Support spec (v0.13.2)](https://riscv.org/wp-content/uploads/2019/03/riscv-debug-release.pdf) specifies that certain accesses to debug module registers while an abstract command is running result in a *busy* value for the `cmderr` field of the `abstractcs` register (Section 3.12.6). (This was originally not fully implemented, see #37, which has been fixed in #79.) However, the spec does not define the response value returned on an access while busy, so that value is defined by the implementation. The current implementation of this debug module always returns `DTM_SUCCESS` as response in `dmi_resp_o` of `dm_csrs`, even though the data in `dmi_resp_o` can be garbage if the debug module was busy during the access. This has been reported in #103.

This PR changes the response in `dmi_resp_o` of `dm_csrs` to `DTM_BUSY` if a command or the SBA was busy when the registers served a new command. This commit also changes the JTAG DMI to take the response into account for reads and return an error code instead of data if the read was not successful.

This PR replaces #104. The problem with gating the DMI request and response handshakes with `~cmdbusy_i` (as PR #104 does) is that the handshakes are stalled until the command is no longer busy. If, for whatever reason, the command remains busy, the DMI will become unresponsive. This is problematic in many cases. Returning a busy response instead gives the DMI (and the software interfacing it) the chance to retry later or execute a different command.