### PR TITLE
dmi_jtag_tap: Bring all state to initial value in Test-Logic-Reset

### DIFF
--- a/src/dmi_jtag_tap.sv
+++ b/src/dmi_jtag_tap.sv
@@ -94,8 +94,9 @@ module dmi_jtag_tap #(
       jtag_ir_d = ir_reg_e'(jtag_ir_shift_q);
     end
 
-    // According to JTAG spec we have to reset the IR to IDCODE in test_logic_reset
     if (test_logic_reset) begin
+      // Bring all TAP state to the initial value.
+      jtag_ir_shift_d = '0;
       jtag_ir_d = IDCODE;
     end
   end
@@ -134,6 +135,12 @@ module dmi_jtag_tap #(
     if (shift_dr) begin
       if (idcode_select)  idcode_d = {td_i, 31'(idcode_q >> 1)};
       if (bypass_select)  bypass_d = td_i;
+    end
+
+    if (test_logic_reset) begin
+      // Bring all TAP state to the initial value.
+      idcode_d = IdcodeValue;
+      bypass_d = 1'b0;
     end
   end
 


### PR DESCRIPTION
This brings all TAP state to the initial value when the controller is in the *Test-Logic-Reset* state. Solves #113.