### PR TITLE
dm_mem: Clear state of hart upon ndmreset

### DIFF
--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -26,6 +26,7 @@ module dm_mem #(
   input  logic                             rst_ni,      // debug module reset
 
   output logic [NrHarts-1:0]               debug_req_o,
+  input  logic                             ndmreset_i,
   input  logic [19:0]                      hartsel_i,
   // from Ctrl and Status register
   input  logic [NrHarts-1:0]               haltreq_i,
@@ -201,6 +202,13 @@ module dm_mem #(
       cmderror_valid_o = 1'b1;
       cmderror_o = dm::CmdErrorException;
     end
+
+    if (ndmreset_i) begin
+      // Clear state of hart and its control signals when it is being reset.
+      state_d = Idle;
+      go      = 1'b0;
+      resume  = 1'b0;
+    end
   end
 
   // word mux for 32bit and 64bit buses
@@ -330,6 +338,12 @@ module dm_mem #(
           default: ;
         endcase
       end
+    end
+
+    if (ndmreset_i) begin
+      // When harts are reset, they are neither halted nor resuming.
+      halted_d_aligned   = '0;
+      resuming_d_aligned = '0;
     end
 
     data_o = data_bits;

--- a/src/dm_top.sv
+++ b/src/dm_top.sv
@@ -86,6 +86,7 @@ module dm_top #(
   logic [dm::DataCount-1:0][31:0]   data_csrs_mem;
   logic [dm::DataCount-1:0][31:0]   data_mem_csrs;
   logic                             data_valid;
+  logic                             ndmreset;
   logic [19:0]                      hartsel;
   // System Bus Access Module
   logic [BusWidth-1:0]              sbaddress_csrs_sba;
@@ -104,6 +105,7 @@ module dm_top #(
   logic                             sberror_valid;
   logic [2:0]                       sberror;
 
+  assign ndmreset_o = ndmreset;
 
   dm_csrs #(
     .NrHarts(NrHarts),
@@ -120,7 +122,7 @@ module dm_top #(
     .dmi_resp_valid_o,
     .dmi_resp_ready_i,
     .dmi_resp_o,
-    .ndmreset_o,
+    .ndmreset_o              ( ndmreset              ),
     .dmactive_o,
     .hartsel_o               ( hartsel               ),
     .hartinfo_i,
@@ -201,6 +203,7 @@ module dm_top #(
     .clk_i,
     .rst_ni,
     .debug_req_o,
+    .ndmreset_i              ( ndmreset              ),
     .hartsel_i               ( hartsel               ),
     .haltreq_i               ( haltreq               ),
     .resumereq_i             ( resumereq             ),


### PR DESCRIPTION
As described in #118, the debug module currently considers a halted hart that is being reset with `ndmreset` to remain halted.  However, after a reset, the hart is no longer halted.

This PR feeds `ndmreset` into `dm_mem`, where it clears the state of the hart and sets it to neither halted nor resuming.