### PR TITLE
Fix debug ROM generator

### DIFF
--- a/debug_rom/Makefile
+++ b/debug_rom/Makefile
@@ -5,7 +5,7 @@ debug_rom = debug_rom.sv debug_rom_one_scratch.sv
 GCC?=riscv64-unknown-elf-gcc
 OBJCOPY?=riscv64-unknown-elf-objcopy
 OBJDUMP?=riscv64-unknown-elf-objdump
-PYTHON?=python
+PYTHON?=python3
 
 all: $(debug_rom)
 

--- a/debug_rom/debug_rom.sv
+++ b/debug_rom/debug_rom.sv
@@ -60,7 +60,7 @@ module debug_rom (
   always_comb begin : p_outmux
     rdata_o = '0;
     if (addr_q < $clog2(RomSize)'(RomSize)) begin
-        rdata_o = mem[addr_q];
+      rdata_o = mem[addr_q];
     end
   end
 

--- a/debug_rom/debug_rom_one_scratch.sv
+++ b/debug_rom/debug_rom_one_scratch.sv
@@ -54,7 +54,7 @@ module debug_rom_one_scratch (
   always_comb begin : p_outmux
     rdata_o = '0;
     if (addr_q < $clog2(RomSize)'(RomSize)) begin
-        rdata_o = mem[addr_q];
+      rdata_o = mem[addr_q];
     end
   end
 

--- a/debug_rom/gen_rom.py
+++ b/debug_rom/gen_rom.py
@@ -88,9 +88,8 @@ $content
 def read_bin():
 
     with open(filename + ".img", 'rb') as f:
-        rom = binascii.hexlify(f.read())
-        rom = map(''.join, zip(rom[::2], rom[1::2]))
-
+        rom = bytes.hex(f.read())
+        rom = list(map(''.join, zip(rom[::2], rom[1::2])))
 
     # align to 64 bit
     align = (int((len(rom) + 7) / 8 )) * 8;

--- a/debug_rom/gen_rom.py
+++ b/debug_rom/gen_rom.py
@@ -68,7 +68,7 @@ $content
   always_comb begin : p_outmux
     rdata_o = '0;
     if (addr_q < $$clog2(RomSize)'(RomSize)) begin
-        rdata_o = mem[addr_q];
+      rdata_o = mem[addr_q];
     end
   end
 


### PR DESCRIPTION
This fixes three issues in the debug ROM generator. Please see commit messages for details. The third commit would replace #108.

Tested by running `make -B` in the `debug_rom` directory; the generated files are exactly the same as those checked into the repo.