### PR TITLE
Add `xprop_off` to Xprop-incompatible processes

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -222,7 +222,7 @@ module dm_csrs #(
   // types instead.
   assign autoexecdata_idx = 4'({dm_csr_addr} - {dm::Data0});
 
-  always_comb begin : csr_read_write
+  always_comb (*xprop_off *) begin : csr_read_write
     // --------------------
     // Static Values (R/O)
     // --------------------

--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -224,7 +224,7 @@ module dm_mem #(
   // read/write logic
   logic [dm::DataCount-1:0][31:0] data_bits;
   logic [7:0][7:0] rdata;
-  always_comb begin : p_rw_logic
+  always_comb (* xprop_off *) begin : p_rw_logic
 
     halted_d_aligned   = NrHartsAligned'(halted_q);
     resuming_d_aligned = NrHartsAligned'(resuming_q);


### PR DESCRIPTION
VCS cannot handle a range in `case inside` constructs when X propagation is enabled.  No semantically equivalent alternative is available (see PR #150), so this commit annotates processes containing the mentioned constructs with `xprop_off` to disable X propagation instrumentation of those processes.

I ran simulations including this change in VCS, Xcelium, and Verilator, and I synthesized the code with Vivado without noticing problems.