### PR TITLE
dm_csrs: Fix W1C behavior of `sberror`

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -463,7 +463,7 @@ module dm_csrs #(
             sbcs_d = sbcs;
             // R/W1C
             sbcs_d.sbbusyerror = sbcs_q.sbbusyerror & (~sbcs.sbbusyerror);
-            sbcs_d.sberror     = sbcs_q.sberror     & {3{~(sbcs.sberror == 3'd1)}};
+            sbcs_d.sberror     = (|sbcs.sberror) ? 3'b0 : sbcs_q.sberror;
           end
         end
         dm::SBAddress0: begin


### PR DESCRIPTION
Prior to this PR, the W1C `sberror` field of the `sbcs` CSR only got cleared when `3b'001` was written to it.  When other values, e.g., `3b111`, were written, the field did not get cleared.  This is a mismatch to the RISC-V External Debug Support spec, which states "Writing 1 to every bit clears the field".

This PR fixes that mismatch in a backwards-compatible way, i.e., now any non-zero write to `sberror`, including `3'b001`, clears it.  See issue #154 for further information and discussion.

This resolves #154.

This has been tested in OpenTitan with OpenOCD connected to this debug module instantiated on an FPGA to confirm that this solves the problem described in lowRISC/opentitan#17729.