### PR TITLE
Misc fixes

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -552,6 +552,9 @@ module dm_csrs #(
     if (dmcontrol_q.resumereq && resumeack_i) begin
       dmcontrol_d.resumereq = 1'b0;
     end
+    // WARL behavior of hartsel, depending on NrHarts.
+    // If NrHarts = 1 this is just masked to all-zeros.
+    {dmcontrol_d.hartselhi, dmcontrol_d.hartsello} &= (2**$clog2(NrHarts))-1;
     // static values for dcsr
     sbcs_d.sbversion            = 3'd1;
     sbcs_d.sbbusy               = sbbusy_i;

--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -35,6 +35,7 @@ module dm_csrs #(
   output dm::dmi_resp_t                     dmi_resp_o,
   // global ctrl
   output logic                              ndmreset_o,      // non-debug module reset active-high
+  input  logic                              ndmreset_ack_i,  // non-debug module reset ack pulse
   output logic                              dmactive_o,      // 1 -> debug-module is active,
                                                              // 0 -> synchronous re-set
   // hart status
@@ -519,8 +520,8 @@ module dm_csrs #(
       data_d = data_i;
     end
 
-    // set the havereset flag when we did a ndmreset
-    if (ndmreset_o) begin
+    // set the havereset flag when the ndmreset completed
+    if (ndmreset_ack_i) begin
       havereset_d_aligned[NrHarts-1:0] = '1;
     end
     // -------------

--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -22,6 +22,7 @@ module dm_csrs #(
 ) (
   input  logic                              clk_i,           // Clock
   input  logic                              rst_ni,          // Asynchronous reset active low
+  input  logic [31:0]                       next_dm_addr_i,  // Static next_dm word address.
   input  logic                              testmode_i,
   input  logic                              dmi_rst_ni,      // sync. DTM reset,
                                                              // active-low
@@ -311,8 +312,8 @@ module dm_csrs #(
         dm::Hartinfo:     resp_queue_inp.data = hartinfo_aligned[selected_hart];
         dm::AbstractCS:   resp_queue_inp.data = abstractcs;
         dm::AbstractAuto: resp_queue_inp.data = abstractauto_q;
-        // command is read-only
-        dm::Command:    resp_queue_inp.data = '0;
+        dm::Command:      resp_queue_inp.data = '0;
+        dm::NextDM:       resp_queue_inp.data = next_dm_addr_i;
         [(dm::ProgBuf0):ProgBufEnd]: begin
           resp_queue_inp.data = progbuf_q[dmi_req_i.addr[$clog2(dm::ProgBufSize)-1:0]];
           if (!cmdbusy_i) begin
@@ -423,6 +424,7 @@ module dm_csrs #(
             end
           end
         end
+        dm::NextDM:; // nextdm is R/O
         dm::AbstractAuto: begin
           // this field can only be written legally when there is no command executing
           if (!cmdbusy_i) begin

--- a/src/dm_obi_top.sv
+++ b/src/dm_obi_top.sv
@@ -133,6 +133,7 @@ module dm_obi_top #(
     .next_dm_addr_i          ( '0                    ), // Note exposed at the top yet.
     .testmode_i              ( testmode_i            ),
     .ndmreset_o              ( ndmreset_o            ),
+    .ndmreset_ack_i          ( ndmreset_o            ), // This is currently not exposed yet.
     .dmactive_o              ( dmactive_o            ),
     .debug_req_o             ( debug_req_o           ),
     .unavailable_i           ( unavailable_i         ),

--- a/src/dm_obi_top.sv
+++ b/src/dm_obi_top.sv
@@ -130,6 +130,7 @@ module dm_obi_top #(
   ) i_dm_top (
     .clk_i                   ( clk_i                 ),
     .rst_ni                  ( rst_ni                ),
+    .next_dm_addr_i          ( '0                    ), // Note exposed at the top yet.
     .testmode_i              ( testmode_i            ),
     .ndmreset_o              ( ndmreset_o            ),
     .dmactive_o              ( dmactive_o            ),

--- a/src/dm_top.sv
+++ b/src/dm_top.sv
@@ -38,6 +38,7 @@ module dm_top #(
   input  logic [31:0]           next_dm_addr_i,
   input  logic                  testmode_i,
   output logic                  ndmreset_o,  // non-debug module reset
+  input  logic                  ndmreset_ack_i, // non-debug module reset acknowledgement pulse
   output logic                  dmactive_o,  // debug module is active
   output logic [NrHarts-1:0]    debug_req_o, // async debug request
   // communicate whether the hart is unavailable (e.g.: power down)
@@ -130,6 +131,7 @@ module dm_top #(
     .dmi_resp_ready_i,
     .dmi_resp_o,
     .ndmreset_o              ( ndmreset              ),
+    .ndmreset_ack_i          ( ndmreset_ack_i        ),
     .dmactive_o,
     .hartsel_o               ( hartsel               ),
     .hartinfo_i,

--- a/src/dm_top.sv
+++ b/src/dm_top.sv
@@ -30,6 +30,12 @@ module dm_top #(
   input  logic                  clk_i,       // clock
   // asynchronous reset active low, connect PoR here, not the system reset
   input  logic                  rst_ni,
+  // Subsequent debug modules can be chained by setting the nextdm register value to the offset of
+  // the next debug module. The RISC-V debug spec mandates that the first debug module located at
+  // 0x0, and that the last debug module in the chain sets the nextdm register to 0x0. The nextdm
+  // register is a word address and not a byte address. This value is passed in as a static signal
+  // so that it becomes possible to assign this value with chiplet tie-offs or straps, if needed.
+  input  logic [31:0]           next_dm_addr_i,
   input  logic                  testmode_i,
   output logic                  ndmreset_o,  // non-debug module reset
   output logic                  dmactive_o,  // debug module is active
@@ -114,6 +120,7 @@ module dm_top #(
   ) i_dm_csrs (
     .clk_i,
     .rst_ni,
+    .next_dm_addr_i,
     .testmode_i,
     .dmi_rst_ni,
     .dmi_req_valid_i,

--- a/tb/tb_test_env.sv
+++ b/tb/tb_test_env.sv
@@ -245,6 +245,7 @@ module tb_test_env #(
 
        .clk_i             ( clk_i             ),
        .rst_ni            ( rst_ni            ),
+       .next_dm_addr_i    ( '0                ),
        .testmode_i        ( 1'b0              ),
        .ndmreset_o        ( ndmreset          ),
        .dmactive_o        (                   ), // active debug session TODO
@@ -258,6 +259,7 @@ module tb_test_env #(
        .slave_be_i        ( dm_be             ),
        .slave_wdata_i     ( dm_wdata          ),
        .slave_rdata_o     ( dm_rdata          ),
+       .slave_err_o       (                   ),
 
        .master_req_o      ( sb_req            ),
        .master_add_o      ( sb_addr           ),


### PR DESCRIPTION
This fixes a few things:
- Implement the `nextdm` register and add a signal input that can be used to input a (static) address.
- Correct behavior of the hartsel register so that it has WARL behavior as defined by the spec.
- Add an acknowledgement input for ndmreset. This is optional, and currently just wired to ndmreset_o in the top-level wrapper. It can however be used to implement more accurate reset completion tracking outside of `rv_dm` (e.g. the system reset manager).

CC @andreaskurth @a-will @gregAC

I will mark this as "ready for review" once I have integrated this into OpenTitan.