### PR TITLE
fix bugs for nrharts

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -547,7 +547,7 @@ module dm_csrs #(
     if (!dmcontrol_q.resumereq && dmcontrol_d.resumereq) begin
       clear_resumeack_o = 1'b1;
     end
-    if (dmcontrol_q.resumereq && resumeack_i) begin
+    if (dmcontrol_q.resumereq && resumeack_i[selected_hart]) begin 
       dmcontrol_d.resumereq = 1'b0;
     end
     // static values for dcsr

--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -535,8 +535,8 @@ module dm_mem #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      halted_q   <= 1'b0;
-      resuming_q <= 1'b0;
+        halted_q   <= '0;
+        resuming_q <= '0;
     end else begin
       halted_q   <= SelectableHarts & halted_d;
       resuming_q <= SelectableHarts & resuming_d;


### PR DESCRIPTION
Fixed **dm_csrs.sv** file to check resumeack_i input as a function of selected_hart in control with multiple harts.

Fixed **dm_mem.sv** reset assignment value for halted_q and resuming_q vectors for nharts.