### PR TITLE
src: Fix wrong reset state for TAP after trst_ni

### DIFF
--- a/src/dmi_jtag_tap.sv
+++ b/src/dmi_jtag_tap.sv
@@ -303,7 +303,7 @@ module dmi_jtag_tap #(
 
   always_ff @(posedge tck_i or negedge trst_ni) begin : p_regs
     if (!trst_ni) begin
-      tap_state_q <= RunTestIdle;
+      tap_state_q <= TestLogicReset;
       idcode_q    <= IdcodeValue;
       bypass_q    <= 1'b0;
     end else begin


### PR DESCRIPTION
This problem was didn't become visible as most/all drivers always run the software reset sequence as trst_ni is an optional signal.

Fixes #165 