### PR TITLE
Critical bug in flow control of dm_csrs

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -183,7 +183,7 @@ module dm_csrs #(
   dm::dmi_resp_t resp_queue_inp;
 
   assign dmi_resp_valid_o     = ~resp_queue_empty;
-  assign dmi_req_ready_o      = ~resp_queue_full;
+  assign dmi_req_ready_o      = ~resp_queue_full & ~sbcs_q.sbbusy;
   assign resp_queue_push      = dmi_req_valid_i & dmi_req_ready_o;
   // SBA
   assign sbautoincrement_o = sbcs_q.sbautoincrement;


### PR DESCRIPTION
This PR fixes a longstanding bug that leads to crashing the JTAG Tap when polling on end of computation (EOC) registers due to the DM_CSRS signaling ready, and the SBCS.sbbusy being deasserted when a request arrives, while the SBCS is still busy.

We found this while debugging in Chimera; even though the JTAG Test methods we use read the SBCS.sbbusy bit before re-issuing a read request, we observe an sbbusyerror that we cannot recover from. This PR fixes this issue, by deasserting the req_ready. My guess is that the timing of sbbusyerror is somehow delayed with respect to the request, but I'll have to dig a bit deeper.

@Lore0599 @adimauro-iis 