### PR TITLE
dm_csrs: Replace fifo_v2 with fifo_v3

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -590,7 +590,7 @@ module dm_csrs #(
   assign ndmreset_o = dmcontrol_q.ndmreset;
 
   // response FIFO
-  fifo_v2 #(
+  fifo_v3 #(
     .dtype            ( logic [$bits(dmi_resp_o)-1:0] ),
     .DEPTH            ( 2                             )
   ) i_fifo (
@@ -601,8 +601,7 @@ module dm_csrs #(
     .testmode_i       ( testmode_i           ),
     .full_o           ( resp_queue_full      ),
     .empty_o          ( resp_queue_empty     ),
-    .alm_full_o       (                      ),
-    .alm_empty_o      (                      ),
+    .usage_o          (                      ),
     .data_i           ( resp_queue_inp       ),
     .push_i           ( resp_queue_push      ),
     .data_o           ( dmi_resp_o           ),

--- a/tb/Makefile
+++ b/tb/Makefile
@@ -119,7 +119,7 @@ RTLSRC_COMMON		:= $(addprefix common_cells/src/,\
 				spill_register_flushable.sv spill_register.sv \
 				cdc_2phase.sv cdc_2phase_clearable.sv \
 				cdc_reset_ctrlr.sv cdc_4phase.sv \
-				deprecated/fifo_v2.sv fifo_v3.sv \
+				fifo_v3.sv \
 				rstgen.sv rstgen_bypass.sv sync.sv)
 RTLSRC_TECH		:= $(addprefix tech_cells_generic/src/,\
 				rtl/tc_clk.sv)


### PR DESCRIPTION
fifo_v2 is deprecated and none of the special thresholding features unique to it are used here, so an update to fifo_v3 is trivial as it only removes the fifio_v2 from the hierarchy but the underlying implementation does not change.