### PR TITLE
tb_jtag_dmi: Fix number of method arguments

### DIFF
--- a/tb/jtag_dmi/tb_jtag_dmi.sv
+++ b/tb/jtag_dmi/tb_jtag_dmi.sv
@@ -238,8 +238,9 @@ module tb_jtag_dmi;
         rsp_mbx.put('h0);
       end else if (transaction.op == dm::DTM_READ) begin
         automatic logic [31:0] rdata;
+        automatic dm::dtm_op_status_e op_status;
         req_mbx.put(transaction);
-        riscv_dbg.read_dmi(dm::dm_csr_e'(transaction.addr), rdata);
+        riscv_dbg.read_dmi(dm::dm_csr_e'(transaction.addr), rdata, 10, op_status);
         rsp_mbx.put(rdata);
       end
       // Randomly reset the dmi using either hard jtag trst_ni, JTAG


### PR DESCRIPTION
The `read_dmi()` method expects 4 arguments, but only 2 are given. Fix this by passing all required arguments. Fixes a slang error (`too few arguments for 'read_dmi'; expected 4 but 2 were provided`)