### PR TITLE
feat: implement halt-on-reset (resethaltreq)

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -48,6 +48,7 @@ module dm_csrs #(
   output logic [NrHarts-1:0]                haltreq_o,       // request to halt a hart
   output logic [NrHarts-1:0]                resumereq_o,     // request hart to resume
   output logic                              clear_resumeack_o,
+  output logic [NrHarts-1:0]                resethaltreq_o,    // halt-on-reset request per hart
 
   output logic                              cmd_valid_o,       // debugger writing to cmd field
   output dm::command_t                      cmd_o,             // abstract command
@@ -174,6 +175,8 @@ module dm_csrs #(
   logic [63:0]        sbdata_d, sbdata_q;
 
   logic [NrHarts-1:0] havereset_d, havereset_q;
+  logic [NrHarts-1:0] resethaltreq_d, resethaltreq_q;
+  logic [HartSelLen-1:0] resethaltsel;
   // program buffer
   logic [dm::ProgBufSize-1:0][31:0] progbuf_d, progbuf_q;
   logic [dm::DataCount-1:0][31:0] data_d, data_q;
@@ -233,8 +236,8 @@ module dm_csrs #(
     dmstatus.version = dm::DbgVersion013;
     // no authentication implemented
     dmstatus.authenticated = 1'b1;
-    // we do not support halt-on-reset sequence
-    dmstatus.hasresethaltreq = 1'b0;
+    // we support the halt-on-reset sequence
+    dmstatus.hasresethaltreq = 1'b1;
     // TODO(zarubaf) things need to change here if we implement the array mask
     dmstatus.allhavereset = havereset_q_aligned[selected_hart];
     dmstatus.anyhavereset = havereset_q_aligned[selected_hart];
@@ -272,6 +275,7 @@ module dm_csrs #(
     // default assignments
     havereset_d_aligned = NrHartsAligned'(havereset_q);
     dmcontrol_d         = dmcontrol_q;
+    resethaltreq_d      = resethaltreq_q;
     cmderr_d            = cmderr_q;
     command_d           = command_q;
     progbuf_d           = progbuf_q;
@@ -291,6 +295,7 @@ module dm_csrs #(
     // helper variables
     sbcs         = '0;
     a_abstractcs = '0;
+    resethaltsel = '0;
 
     // reads
     if (dmi_req_ready_o && dmi_req_valid_i && dtm_op == dm::DTM_READ) begin
@@ -390,6 +395,12 @@ module dm_csrs #(
           // clear the havreset of the selected hart
           if (dmcontrol_d.ackhavereset) begin
             havereset_d_aligned[selected_hart] = 1'b0;
+          end
+          // halt-on-reset: set/clear applies to the hart selected by THIS write
+          resethaltsel = HartSelLen'({dmcontrol_d.hartselhi, dmcontrol_d.hartsello});
+          if (resethaltsel <= HartSelLen'(NrHarts-1)) begin
+            if (dmcontrol_d.setresethaltreq) resethaltreq_d[resethaltsel] = 1'b1;
+            if (dmcontrol_d.clrresethaltreq) resethaltreq_d[resethaltsel] = 1'b0;
           end
         end
         dm::DMStatus:; // write are ignored to R/O register
@@ -580,6 +591,7 @@ module dm_csrs #(
   end
 
   assign dmactive_o  = dmcontrol_q.dmactive;
+  assign resethaltreq_o = resethaltreq_q;
   assign cmd_o       = command_q;
   assign cmd_valid_o = cmd_valid_q;
   assign progbuf_o   = progbuf_q;
@@ -623,6 +635,7 @@ module dm_csrs #(
       sbaddr_q       <= '0;
       sbdata_q       <= '0;
       havereset_q    <= '1;
+      resethaltreq_q <= '0;
     end else begin
       havereset_q    <= SelectableHarts & havereset_d;
       // synchronous re-set of debug module, active-low, except for dmactive
@@ -639,6 +652,7 @@ module dm_csrs #(
         dmcontrol_q.setresethaltreq  <= '0;
         dmcontrol_q.clrresethaltreq  <= '0;
         dmcontrol_q.ndmreset         <= '0;
+        resethaltreq_q               <= '0;
         // this is the only write-able bit during reset
         dmcontrol_q.dmactive         <= dmcontrol_d.dmactive;
         cmderr_q                     <= dm::CmdErrNone;
@@ -652,6 +666,7 @@ module dm_csrs #(
         sbdata_q                     <= '0;
       end else begin
         dmcontrol_q                  <= dmcontrol_d;
+        resethaltreq_q               <= resethaltreq_d;
         cmderr_q                     <= cmderr_d;
         command_q                    <= command_d;
         cmd_valid_q                  <= cmd_valid_d;

--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -30,6 +30,7 @@ module dm_mem #(
   input  logic [19:0]                      hartsel_i,
   // from Ctrl and Status register
   input  logic [NrHarts-1:0]               haltreq_i,
+  input  logic [NrHarts-1:0]               resethaltreq_i,   // halt-on-reset armed, per hart
   input  logic [NrHarts-1:0]               resumereq_i,
   input  logic                             clear_resumeack_i,
 
@@ -86,6 +87,7 @@ module dm_mem #(
   logic [7:0][63:0]   abstract_cmd;
   logic [NrHarts-1:0] halted_d, halted_q;
   logic [NrHarts-1:0] resuming_d, resuming_q;
+  logic [NrHarts-1:0] resethaltpend_d, resethaltpend_q;
   logic               resume, go, going;
 
   logic exception;
@@ -123,9 +125,23 @@ module dm_mem #(
 
   // Abstract Command Access Register
   assign ac_ar       = dm::ac_ar_cmd_t'(cmd_i.control);
-  assign debug_req_o = haltreq_i;
+  assign debug_req_o = haltreq_i | resethaltpend_q;
   assign halted_o    = halted_q;
   assign resuming_o  = resuming_q;
+
+  // Halt-on-reset: arm while a hart is held in ndmreset with resethaltreq set; hold debug_req
+  // across reset deassert until the hart enters debug (reports halted), then clear. Clearing
+  // resethaltreq also cancels a pending halt.
+  always_comb begin : p_resethalt
+    resethaltpend_d = resethaltpend_q;
+    for (int unsigned h = 0; h < NrHarts; h++) begin
+      if (ndmreset_i && resethaltreq_i[h]) begin
+        resethaltpend_d[h] = 1'b1;
+      end else if (halted_q[h] || !resethaltreq_i[h]) begin
+        resethaltpend_d[h] = 1'b0;
+      end
+    end
+  end
 
   // reshape progbuf
   assign progbuf = progbuf_i;
@@ -535,11 +551,13 @@ module dm_mem #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      halted_q   <= 1'b0;
-      resuming_q <= 1'b0;
+      halted_q        <= 1'b0;
+      resuming_q      <= 1'b0;
+      resethaltpend_q <= '0;
     end else begin
-      halted_q   <= SelectableHarts & halted_d;
-      resuming_q <= SelectableHarts & resuming_d;
+      halted_q        <= SelectableHarts & halted_d;
+      resuming_q      <= SelectableHarts & resuming_d;
+      resethaltpend_q <= SelectableHarts & resethaltpend_d;
     end
   end
 

--- a/src/dm_top.sv
+++ b/src/dm_top.sv
@@ -81,6 +81,7 @@ module dm_top #(
   // logic [NrHarts-1:0]               running;
   logic [NrHarts-1:0]               resumeack;
   logic [NrHarts-1:0]               haltreq;
+  logic [NrHarts-1:0]               resethaltreq;
   logic [NrHarts-1:0]               resumereq;
   logic                             clear_resumeack;
   logic                             cmd_valid;
@@ -141,6 +142,7 @@ module dm_top #(
     .haltreq_o               ( haltreq               ),
     .resumereq_o             ( resumereq             ),
     .clear_resumeack_o       ( clear_resumeack       ),
+    .resethaltreq_o          ( resethaltreq          ),
     .cmd_valid_o             ( cmd_valid             ),
     .cmd_o                   ( cmd                   ),
     .cmderror_valid_i        ( cmderror_valid        ),
@@ -215,6 +217,7 @@ module dm_top #(
     .ndmreset_i              ( ndmreset              ),
     .hartsel_i               ( hartsel               ),
     .haltreq_i               ( haltreq               ),
+    .resethaltreq_i          ( resethaltreq          ),
     .resumereq_i             ( resumereq             ),
     .clear_resumeack_i       ( clear_resumeack       ),
     .halted_o                ( halted                ),


### PR DESCRIPTION
Closes #187.

Implements the halt-on-reset sequence so a debugger can halt a hart at its first instruction out of reset (needed for early-boot / secure-boot / ROM debugging, where a software `ebreak` can't be planted).

### What changed
- `dm_csrs.sv`: `dmstatus.hasresethaltreq = 1`; per-hart `resethaltreq` state backed by `dmcontrol.set/clrresethaltreq` (applied to the hart selected by the same write); survives `ndmreset`, cleared on PoR / `dmactive=0`.
- - `dm_mem.sv`: per-hart `resethaltpend` armed while a hart is held in `ndmreset` with `resethaltreq` set, held across reset deassert until the hart reports halted (or the request is cleared); `debug_req_o = haltreq_i | resethaltpend_q`.
- - `dm_top.sv`: wires the new signal `dm_csrs` -> `dm_mem` internally.
Routed through the existing `debug_req_o` rather than adding a new `dm_top` output, so the module interface is unchanged and existing integrators get halt-on-reset with no wiring changes (verified: `dm_obi_top` needs no edits and still elaborates). Happy to also expose a status output if you'd prefer.

### Scope / limitation
Enforced for `ndmreset` (which the DM survives, being in the always-on domain); a full PoR that also resets the DM clears `resethaltreq` and the debugger re-arms — inherent to the DM's view of resets. `dmcontrol.hartreset` remains hardwired 0.

### Testing
- Elaborates latch-free under Verilator with zero new warnings vs. baseline.
- - Directed self-checking testbench (drives the DMI side, models the hart-side halt handshake): `NrHarts=1` 10/10 and `NrHarts=2` 14/14 — covers `hasresethaltreq=1`, `debug_req` held across `ndmreset` then dropped once halted (so resume works), re-arm on a second reset (not one-shot), `clrresethaltreq` cancels, and per-hart independence. Glad to contribute the testbench if useful.
- - Behavior is unchanged when inactive (`resethaltreq==0` => `debug_req_o == haltreq_i`). The full OpenOCD/cv32e40p core-in-the-loop regression runs in CI.
*Developed with AI assistance (design + draft); I have reviewed and tested the entire change.*