### PR TITLE
dm: Decouple abstract register width from bus width 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,7 +87,11 @@ jobs:
       - name: Run Ruff
         run: uvx --from ruff==0.16.0 ruff check debug_rom/gen_rom.py tb/veri-run-openocd.py
       - name: Run tclint
-        run: uvx --from tclint==0.4.2 tclint tb/vsim_batch.tcl tb/vsim_gui.tcl
+        run: |
+          uvx --from tclint==0.4.2 tclint \
+            tb/dm_mem/test_access_widths_vsim.tcl \
+            tb/vsim_batch.tcl \
+            tb/vsim_gui.tcl
 
   verilator:
     name: Verilator lint

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -49,6 +49,6 @@ jobs:
           bender --version
           riscv64-unknown-elf-gcc --version
           z3 --version
-      - name: Run JTAG and compliance regressions
+      - name: Run Verilator regressions
         shell: bash
         run: make -C ci -j2 NUM_JOBS=2 all

--- a/Bender.yml
+++ b/Bender.yml
@@ -47,3 +47,7 @@ sources:
     - tb/jtag_dmi/jtag_test.sv
     # Level 3
     - tb/jtag_dmi/tb_jtag_dmi.sv
+
+  - target: dm_mem_test
+    files:
+    - tb/dm_mem/tb_dm_mem.sv

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ debugging.
 ## Features
 The following features are currently supported
 
-* Parametrizable buswidth for `XLEN=32` `XLEN=64` cores
-* Accessing registers over abstract command
+* Parametrizable 32- or 64-bit debug-module bus width, independent of hart XLEN
+* Accessing 32- or 64-bit hart registers over abstract commands
 * Program buffer
 * System bus access (only `XLEN`)
 * DTM with JTAG interface

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -11,9 +11,9 @@ TB := $(ROOT)/tb
 NUM_JOBS ?= 2
 OPENOCD_PREFIX ?= $(ROOT)/.cache/openocd
 
-.PHONY: all compliance firmware full-model jtag-dmi openocd
+.PHONY: all compliance dm-mem firmware full-model jtag-dmi openocd
 
-all: jtag-dmi compliance
+all: dm-mem jtag-dmi compliance
 
 full-model:
 	$(MAKE) -C $(TB) -j1 download_deps
@@ -29,6 +29,10 @@ openocd:
 jtag-dmi:
 	JTAG_BUILD_DIR=$(ROOT)/build/jtag-verilator \
 		$(ROOT)/ci/run-jtag-verilator.sh
+
+dm-mem:
+	DM_MEM_BUILD_DIR=$(ROOT)/build/dm-mem-verilator \
+		$(ROOT)/ci/run-dm-mem-verilator.sh
 
 compliance: full-model firmware openocd
 	cd $(TB) && \

--- a/ci/run-dm-mem-verilator.sh
+++ b/ci/run-dm-mem-verilator.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Authors:
+# - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+set -euo pipefail
+
+readonly ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly BUILD_DIR="${DM_MEM_BUILD_DIR:-${ROOT}/build/dm-mem-verilator}"
+readonly FILE_LIST="${BUILD_DIR}/sources.flist"
+
+# Fields: name BusWidth MaxRegisterAccessWidth HartSel AarSize ExpectSupported
+readonly TEST_CASES=(
+  "bus32_max32_aar32 32 32 0 2 1"
+  "bus32_max32_aar64 32 32 1 3 0"
+  "bus32_max64_aar32 32 64 0 2 1"
+  "bus32_max64_aar64 32 64 1 3 1"
+  "bus64_max32_aar32 64 32 1 2 1"
+  "bus64_max32_aar64 64 32 0 3 0"
+  "bus64_max64_aar64 64 64 1 3 1"
+)
+
+mkdir -p "${BUILD_DIR}"
+cd "${ROOT}"
+
+bender checkout
+bender script flist-plus \
+  --relative-path \
+  -t riscv-dbg:dm_mem_test \
+  -t tech_cells_generic:tech_cells_generic_exclude_deprecated \
+  > "${FILE_LIST}"
+
+for test_case in "${TEST_CASES[@]}"; do
+  read -r name bus_width max_access_width hart_sel aar_size expect_supported <<< "${test_case}"
+  case_build_dir="${BUILD_DIR}/${name}"
+  mkdir -p "${case_build_dir}"
+
+  verilator \
+    --binary \
+    --timing \
+    -Wno-fatal \
+    -DCOMMON_CELLS_ASSERTS_OFF \
+    --top-module tb_dm_mem \
+    --Mdir "${case_build_dir}/obj_dir" \
+    -GBusWidth="${bus_width}" \
+    -GMaxRegisterAccessWidth="${max_access_width}" \
+    -GHartSel="${hart_sel}" \
+    -GAarSize="${aar_size}" \
+    -GExpectSupported="${expect_supported}" \
+    -f "${FILE_LIST}"
+
+  "${case_build_dir}/obj_dir/Vtb_dm_mem"
+done

--- a/doc/debug-system.md
+++ b/doc/debug-system.md
@@ -132,6 +132,7 @@ The debug system can be configured at synthesis time through parameters.
 NrHarts            | 1..2^20          | 1           | Number of connected harts
 BusWidth           | 32, 64           | 32          | Bus width (for debug memory and SBA busses)
 SelectableHarts    |                  | 1           | Bitmask to select physically available harts for systems that don't use hart numbers in a contiguous fashion.
+MaxRegisterAccessWidth | 32, 64       | BusWidth    | Maximum Access Register abstract-command width supported by the connected harts, independent of the debug-memory bus width. For heterogeneous systems, set this to the maximum XLEN among the connected harts.
 
 In addition to these parameters, additional configuration is provided through top-level signals, which are expected to be set to a fixed value at synthesis time.
 

--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -20,7 +20,9 @@ module dm_mem #(
   parameter int unsigned        NrHarts          =  1,
   parameter int unsigned        BusWidth         = 32,
   parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}},
-  parameter int unsigned        DmBaseAddress    = '0
+  parameter int unsigned        DmBaseAddress          = '0,
+  // Maximum width supported by Access Register commands; must be 32 or 64.
+  parameter int unsigned        MaxRegisterAccessWidth = BusWidth
 ) (
   input  logic                             clk_i,       // Clock
   input  logic                             rst_ni,      // debug module reset
@@ -62,7 +64,7 @@ module dm_mem #(
   localparam int unsigned DataIndexWidth = $clog2(dm::DataCount);
   localparam int unsigned HartSelLen     = (NrHarts == 1) ? 1 : $clog2(NrHarts);
   localparam int unsigned NrHartsAligned = 2**HartSelLen;
-  localparam int unsigned MaxAar         = (BusWidth == 64) ? 4 : 3;
+  localparam int unsigned MaxAar         = (MaxRegisterAccessWidth == 64) ? 4 : 3;
   localparam bit          HasSndScratch  = (DmBaseAddress != 0);
   // Depending on whether we are at the zero page or not we either use `x0` or `x10/a0`
   localparam logic [4:0]  LoadBaseAddr   = (DmBaseAddress == 0) ? 5'd0 : 5'd10;
@@ -82,6 +84,11 @@ module dm_mem #(
   localparam logic [DbgAddressBits-1:0] GoingAddr     = 'h108;
   localparam logic [DbgAddressBits-1:0] ResumingAddr  = 'h110;
   localparam logic [DbgAddressBits-1:0] ExceptionAddr = 'h118;
+
+  initial begin : p_validate_max_register_access_width
+    assert (MaxRegisterAccessWidth == 32 || MaxRegisterAccessWidth == 64) else
+      $fatal(1, "MaxRegisterAccessWidth must be 32 or 64.");
+  end
 
   logic [dm::ProgBufSize/2-1:0][63:0]   progbuf;
   logic [7:0][63:0]   abstract_cmd;

--- a/src/dm_obi_top.sv
+++ b/src/dm_obi_top.sv
@@ -67,7 +67,9 @@ module dm_obi_top #(
   parameter int unsigned        DmBaseAddress    = 'h1000, // default to non-zero page
   // Bitmask to select physically available harts for systems
   // that don't use hart numbers in a contiguous fashion.
-  parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}}
+  parameter logic [NrHarts-1:0] SelectableHarts        = {NrHarts{1'b1}},
+  // Maximum width supported by Access Register commands; must be 32 or 64.
+  parameter int unsigned        MaxRegisterAccessWidth = BusWidth
 ) (
   input  logic                  clk_i,           // clock
   // asynchronous reset active low, connect PoR here, not the system reset
@@ -123,10 +125,11 @@ module dm_obi_top #(
 
   // dm_top instance
   dm_top #(
-    .NrHarts                 ( NrHarts               ),
-    .BusWidth                ( BusWidth              ),
-    .DmBaseAddress           ( DmBaseAddress         ),
-    .SelectableHarts         ( SelectableHarts       )
+    .NrHarts                ( NrHarts                ),
+    .BusWidth               ( BusWidth               ),
+    .DmBaseAddress          ( DmBaseAddress          ),
+    .SelectableHarts        ( SelectableHarts        ),
+    .MaxRegisterAccessWidth ( MaxRegisterAccessWidth )
   ) i_dm_top (
     .clk_i                   ( clk_i                 ),
     .rst_ni                  ( rst_ni                ),

--- a/src/dm_top.sv
+++ b/src/dm_top.sv
@@ -25,7 +25,9 @@ module dm_top #(
   // that don't use hart numbers in a contiguous fashion.
   parameter logic [NrHarts-1:0] SelectableHarts  = {NrHarts{1'b1}},
   // toggle new behavior to drive master_be_o during a read
-  parameter bit                 ReadByteEnable   = 1
+  parameter bit                 ReadByteEnable         = 1,
+  // Maximum width supported by Access Register commands; must be 32 or 64.
+  parameter int unsigned        MaxRegisterAccessWidth = BusWidth
 ) (
   input  logic                  clk_i,       // clock
   // asynchronous reset active low, connect PoR here, not the system reset
@@ -204,10 +206,11 @@ module dm_top #(
   );
 
   dm_mem #(
-    .NrHarts(NrHarts),
-    .BusWidth(BusWidth),
-    .SelectableHarts(SelectableHarts),
-    .DmBaseAddress(DmBaseAddress)
+    .NrHarts                ( NrHarts                ),
+    .BusWidth               ( BusWidth               ),
+    .SelectableHarts        ( SelectableHarts        ),
+    .DmBaseAddress          ( DmBaseAddress          ),
+    .MaxRegisterAccessWidth ( MaxRegisterAccessWidth )
   ) i_dm_mem (
     .clk_i,
     .rst_ni,

--- a/tb/dm_mem/run_vsim.sh
+++ b/tb/dm_mem/run_vsim.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Authors:
+# - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+#
+# Compiles the dm_mem testbench once and runs its Questa parameter matrix.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+BUILD_DIR=$(mktemp -d)
+trap 'rm -r "${BUILD_DIR}"' EXIT
+
+BENDER=${BENDER:-bender}
+VSIM=${VSIM:-vsim}
+
+cd "${ROOT}"
+"${BENDER}" script vsim -n -t dm_mem_test \
+  --vlog-arg="-svinputport=compat" \
+  --vlog-arg="-override_timescale 1ns/1ps" \
+  > "${BUILD_DIR}/compile.tcl"
+echo 'return 0' >> "${BUILD_DIR}/compile.tcl"
+
+cd "${BUILD_DIR}"
+"${VSIM}" -c -do 'exit -code [source compile.tcl]'
+"${VSIM}" -c -do "source {${ROOT}/tb/dm_mem/test_access_widths_vsim.tcl}"

--- a/tb/dm_mem/tb_dm_mem.sv
+++ b/tb/dm_mem/tb_dm_mem.sv
@@ -1,0 +1,245 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors:
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+//
+// Checks Access Register command acceptance and instruction generation for independent bus and
+// register widths. It also verifies the two-word debug-memory mapping used for 64-bit accesses on
+// a 32-bit bus without modeling a processor core.
+
+module tb_dm_mem #(
+  parameter int unsigned BusWidth               = 32,
+  parameter int unsigned MaxRegisterAccessWidth = BusWidth,
+  parameter int unsigned HartSel                = 0,
+  parameter int unsigned AarSize                = 2,
+  parameter bit          ExpectSupported        = 1'b1
+);
+
+  localparam int unsigned NrHarts = 2;
+
+  localparam logic [11:0] HaltedAddr      = 12'h100;
+  localparam logic [11:0] AbstractCmdAddr = dm::DataAddr - 4 * dm::ProgBufSize - 4 * 10 + 16;
+  localparam logic [11:0] DataEndAddr     = dm::DataAddr + 4 * dm::DataCount - 1;
+
+  logic                             clk, rst_n;
+  logic                             req, we;
+  logic [BusWidth-1:0]              addr, wdata, rdata;
+  logic [BusWidth/8-1:0]            be;
+  logic [NrHarts-1:0]               halted;
+  logic [dm::ProgBufSize-1:0][31:0] progbuf;
+  logic [dm::DataCount-1:0][31:0]   data_in, data_out;
+  logic                             data_valid, cmd_valid, write_register, cmderror_valid;
+  dm::command_t                     command;
+  dm::ac_ar_cmd_t                   access_register;
+  dm::cmderr_e                      cmderror;
+
+  initial begin
+    clk = 1'b0;
+    forever #5ns clk = ~clk;
+  end
+
+  initial begin
+    rst_n = 1'b0;
+    repeat (3) @(posedge clk);
+    rst_n = 1'b1;
+  end
+
+  always_comb begin
+    access_register                  = '0;
+    access_register.aarsize          = 3'(AarSize);
+    access_register.transfer         = 1'b1;
+    access_register.write            = write_register;
+    access_register.regno            = 16'h1001;
+    command                          = '0;
+    command.cmdtype                  = dm::AccessRegister;
+    command.control                  = access_register;
+  end
+
+  dm_mem #(
+    .NrHarts                ( NrHarts                ),
+    .BusWidth               ( BusWidth               ),
+    .MaxRegisterAccessWidth ( MaxRegisterAccessWidth )
+  ) i_dm_mem (
+    .clk_i                ( clk                    ),
+    .rst_ni               ( rst_n                  ),
+    .debug_req_o          (                        ),
+    .ndmreset_i           ( 1'b0                   ),
+    .hartsel_i            ( 20'(HartSel)            ),
+    .haltreq_i            ( '0                     ),
+    .resumereq_i          ( '0                     ),
+    .clear_resumeack_i    ( 1'b0                   ),
+    .halted_o             ( halted                 ),
+    .resuming_o           (                        ),
+    .progbuf_i            ( progbuf                ),
+    .data_i               ( data_in                ),
+    .data_o               ( data_out               ),
+    .data_valid_o         ( data_valid             ),
+    .cmd_valid_i          ( cmd_valid              ),
+    .cmd_i                ( command                ),
+    .cmderror_valid_o     ( cmderror_valid         ),
+    .cmderror_o           ( cmderror               ),
+    .cmdbusy_o            (                        ),
+    .req_i                ( req                    ),
+    .we_i                 ( we                     ),
+    .addr_i               ( addr                   ),
+    .wdata_i              ( wdata                  ),
+    .be_i                 ( be                     ),
+    .rdata_o              ( rdata                  )
+  );
+
+  task automatic start_debug_memory_access(
+    input bit                  write,
+    input logic [11:0]         access_addr,
+    input logic [BusWidth-1:0] write_data
+  );
+    req   = 1'b1;
+    we    = write;
+    addr  = BusWidth'(access_addr);
+    wdata = write_data;
+    be    = write ? '1 : '0;
+  endtask
+
+  task automatic finish_debug_memory_access;
+    req   = 1'b0;
+    we    = 1'b0;
+    addr  = '0;
+    wdata = '0;
+    be    = '0;
+  endtask
+
+  task automatic write_debug_memory(
+    input logic [11:0]         write_addr,
+    input logic [BusWidth-1:0] write_data
+  );
+    bit writes_data_register;
+
+    writes_data_register = write_addr inside {[dm::DataAddr:DataEndAddr]};
+    @(negedge clk);
+    start_debug_memory_access(1'b1, write_addr, write_data);
+    #1ns;
+    if (data_valid !== writes_data_register) begin
+      $fatal(1, "write to %03x produced data_valid=%0b, expected %0b",
+             write_addr, data_valid, writes_data_register);
+    end
+    if (writes_data_register) begin
+      // Model the CSR storage driven by data_o/data_valid_o in the full debug module.
+      data_in = data_out;
+    end
+    @(negedge clk);
+    finish_debug_memory_access();
+    #1ns;
+    if (data_valid) begin
+      $fatal(1, "data_valid remained asserted after write to %03x", write_addr);
+    end
+  endtask
+
+  task automatic read_debug_memory(
+    input  logic [11:0]         read_addr,
+    output logic [BusWidth-1:0] read_data
+  );
+    @(negedge clk);
+    start_debug_memory_access(1'b0, read_addr, '0);
+    @(negedge clk);
+    #1ns;
+    read_data = rdata;
+    finish_debug_memory_access();
+  endtask
+
+  task automatic check_access_register(input bit write_register_value);
+    logic [BusWidth-1:0] read_data;
+    logic [31:0]         expected_instruction;
+
+    write_register = write_register_value;
+    cmd_valid      = 1'b1;
+    #1ns;
+    if (ExpectSupported) begin
+      if (cmderror_valid) begin
+        $fatal(1, "aarsize %0d write=%0b unexpectedly rejected with cmderr %0d",
+               AarSize, write_register_value, cmderror);
+      end
+    end else begin
+      if (!cmderror_valid || cmderror != dm::CmdErrNotSupported) begin
+        $fatal(1, "aarsize %0d write=%0b was not rejected as unsupported",
+               AarSize, write_register_value);
+      end
+    end
+    cmd_valid = 1'b0;
+
+    if (!ExpectSupported) begin
+      return;
+    end
+
+    read_debug_memory(AbstractCmdAddr, read_data);
+    expected_instruction = write_register_value ?
+        dm::load(3'(AarSize), 5'd1, 5'd0, dm::DataAddr) :
+        dm::store(3'(AarSize), 5'd1, 5'd0, dm::DataAddr);
+    if (read_data[31:0] !== expected_instruction) begin
+      $fatal(1, "generated instruction %08x does not match expected %08x for write=%0b",
+             read_data[31:0], expected_instruction, write_register_value);
+    end
+  endtask
+
+  task automatic check_64_over_32_data_mapping;
+    logic [BusWidth-1:0] read_data;
+    localparam logic [31:0] StoreLowWord  = 32'h0123_4567;
+    localparam logic [31:0] StoreHighWord = 32'h89ab_cdef;
+    localparam logic [31:0] LoadLowWord   = 32'h7654_3210;
+    localparam logic [31:0] LoadHighWord  = 32'hfedc_ba98;
+
+    if (BusWidth != 32 || MaxRegisterAccessWidth != 64 || AarSize != 3 || !ExpectSupported) begin
+      return;
+    end
+
+    data_in = '0;
+    write_debug_memory(dm::DataAddr, BusWidth'(StoreLowWord));
+    write_debug_memory(dm::DataAddr + 4, BusWidth'(StoreHighWord));
+    if (data_in[0] !== StoreLowWord || data_in[1] !== StoreHighWord) begin
+      $fatal(1, "64-bit store mapping is %08x_%08x, expected %08x_%08x",
+             data_in[1], data_in[0], StoreHighWord, StoreLowWord);
+    end
+
+    data_in[0] = LoadLowWord;
+    data_in[1] = LoadHighWord;
+    read_debug_memory(dm::DataAddr, read_data);
+    if (read_data[31:0] !== LoadLowWord) begin
+      $fatal(1, "data0 read returned %08x, expected %08x", read_data[31:0], LoadLowWord);
+    end
+    read_debug_memory(dm::DataAddr + 4, read_data);
+    if (read_data[31:0] !== LoadHighWord) begin
+      $fatal(1, "data1 read returned %08x, expected %08x", read_data[31:0], LoadHighWord);
+    end
+  endtask
+
+  initial begin
+    finish_debug_memory_access();
+    progbuf        = '0;
+    data_in        = '0;
+    cmd_valid      = 1'b0;
+    write_register = 1'b0;
+
+    @(posedge rst_n);
+
+    // Mark the selected hart halted through the architected debug-memory handshake.
+    write_debug_memory(HaltedAddr, BusWidth'(HartSel));
+
+    if (!halted[HartSel]) begin
+      $fatal(1, "failed to halt hart %0d", HartSel);
+    end
+
+    check_access_register(1'b0);
+    check_access_register(1'b1);
+    check_64_over_32_data_mapping();
+
+    $display("tb_dm_mem: BusWidth=%0d MaxRegisterAccessWidth=%0d HartSel=%0d AarSize=%0d passed",
+             BusWidth, MaxRegisterAccessWidth, HartSel, AarSize);
+    $finish;
+  end
+
+  initial begin
+    #2us;
+    $fatal(1, "tb_dm_mem: timeout");
+  end
+
+endmodule

--- a/tb/dm_mem/test_access_widths_vsim.tcl
+++ b/tb/dm_mem/test_access_widths_vsim.tcl
@@ -1,0 +1,62 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Authors:
+# - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+#
+# Re-elaborates tb_dm_mem across register-access and bus-width configurations.
+# Each run is logged, and any Questa error or fatal makes the script fail.
+
+set regression_failed 0
+file mkdir logs
+
+proc run_access_width_test {
+    name bus_width max_access_width hart_sel aar_size expect_supported
+} {
+    global regression_failed
+
+    puts "================================================================"
+    puts [format "= Running %s: bus=%d max_access=%d hart=%d aarsize=%d" \
+        $name $bus_width $max_access_width $hart_sel $aar_size]
+    puts "================================================================"
+
+    set transcript_name "logs/dm_mem.${name}.vsim.log"
+    file delete -force $transcript_name
+    transcript file $transcript_name
+
+    vsim -t 1ps -voptargs=+acc -sv_seed 1 \
+        -GBusWidth=$bus_width \
+        -GMaxRegisterAccessWidth=$max_access_width \
+        -GHartSel=$hart_sel \
+        -GAarSize=$aar_size \
+        -GExpectSupported=$expect_supported \
+        -wlf "logs/dm_mem.${name}.wlf" \
+        tb_dm_mem
+
+    onfinish stop
+    set StdArithNoWarnings 1
+    set NumericStdNoWarnings 1
+    run -all
+    quit -sim
+
+    transcript file {}
+    set transcript_fd [open $transcript_name r]
+    set transcript_data [read $transcript_fd]
+    close $transcript_fd
+    if {[regexp -line {^# \*\* (Error|Fatal)( \([^)]*\))?:} $transcript_data]} {
+        puts "Regression errors detected in $transcript_name"
+        set regression_failed 1
+    }
+}
+
+# Fields: name BusWidth MaxRegisterAccessWidth HartSel AarSize ExpectSupported
+run_access_width_test bus32_max32_aar32 32 32 0 2 1
+run_access_width_test bus32_max32_aar64 32 32 1 3 0
+run_access_width_test bus32_max64_aar32 32 64 0 2 1
+run_access_width_test bus32_max64_aar64 32 64 1 3 1
+run_access_width_test bus64_max32_aar32 64 32 1 2 1
+run_access_width_test bus64_max32_aar64 64 32 0 3 0
+run_access_width_test bus64_max64_aar64 64 64 1 3 1
+
+quit -code $regression_failed -f


### PR DESCRIPTION
Takes #83, cleans it up and adds tests to cover the different cases where the widths do not match.