### PR TITLE
tb: Preserve fractional simulation delays

### DIFF
--- a/src/dmi_test.sv
+++ b/src/dmi_test.sv
@@ -40,8 +40,8 @@ package dmi_test;
   /// A driver for the DMI interface.
   class dmi_driver #(
     parameter int  AW = -1,
-    parameter time TA = 0 , // stimuli application time
-    parameter time TT = 0   // stimuli test time
+    parameter realtime TA = 0 , // stimuli application time
+    parameter realtime TT = 0   // stimuli test time
   );
     virtual DMI_BUS_DV #(
       .ADDR_WIDTH(AW)
@@ -159,8 +159,8 @@ package dmi_test;
     // dmi interface parameters
     parameter int   AW = 32,
     // Stimuli application and test time
-    parameter time  TA = 0ps,
-    parameter time  TT = 0ps
+    parameter realtime  TA = 0ps,
+    parameter realtime  TT = 0ps
   );
 
     typedef dmi_test::dmi_driver #(
@@ -197,8 +197,8 @@ package dmi_test;
     // dmi interface parameters
     parameter int   AW = 32,
     // Stimuli application and test time
-    parameter time  TA = 0ps,
-    parameter time  TT = 0ps,
+    parameter realtime  TA = 0ps,
+    parameter realtime  TT = 0ps,
     parameter int unsigned REQ_MIN_WAIT_CYCLES = 1,
     parameter int unsigned REQ_MAX_WAIT_CYCLES = 20,
     parameter int unsigned RSP_MIN_WAIT_CYCLES = 1,
@@ -253,8 +253,8 @@ package dmi_test;
     // dmi interface parameters
     parameter int   AW = 32,
     // Stimuli application and test time
-    parameter time  TA = 0ps,
-    parameter time  TT = 0ps,
+    parameter realtime  TA = 0ps,
+    parameter realtime  TT = 0ps,
     parameter int unsigned REQ_MIN_WAIT_CYCLES = 0,
     parameter int unsigned REQ_MAX_WAIT_CYCLES = 10,
     parameter int unsigned RSP_MIN_WAIT_CYCLES = 0,
@@ -307,8 +307,8 @@ package dmi_test;
     // dmi interface parameters
     parameter int   AW = 32,
     // Stimuli application and test time
-    parameter time  TA = 0ps,
-    parameter time  TT = 0ps
+    parameter realtime  TA = 0ps,
+    parameter realtime  TT = 0ps
   ) extends rand_dmi #(.AW(AW), .TA(TA), .TT(TT));
 
     mailbox #(req_t) req_mbx = new;

--- a/tb/jtag_dmi/jtag_test.sv
+++ b/tb/jtag_dmi/jtag_test.sv
@@ -11,8 +11,8 @@ package jtag_test;
   class jtag_driver #(
     parameter int IrLength = 0,
     parameter logic [IrLength-1:0] IDCODE = 'h1,
-    parameter time TA = 0ns , // stimuli application time
-    parameter time TT = 0ns   // stimuli test time
+    parameter realtime TA = 0ns , // stimuli application time
+    parameter realtime TT = 0ns   // stimuli test time
   );
 
     virtual JTAG_DV jtag;
@@ -130,8 +130,8 @@ package jtag_test;
     parameter logic [IrLength-1:0] IDCODE    = 'h1,
     parameter logic [IrLength-1:0] DTMCSR    = 'h10,
     parameter logic [IrLength-1:0] DMIACCESS = 'h11,
-    parameter time TA = 0ns, // stimuli application time
-    parameter time TT = 0ns  // stimuli test time
+    parameter realtime TA = 0ns, // stimuli application time
+    parameter realtime TT = 0ns  // stimuli test time
   );
 
     typedef jtag_test::jtag_driver #(

--- a/tb/jtag_dmi/tb_jtag_dmi.sv
+++ b/tb/jtag_dmi/tb_jtag_dmi.sv
@@ -7,11 +7,11 @@ module tb_jtag_dmi;
 
   logic clk, rst_n;
 
-  localparam time ClkPeriod = 10ns;
-  localparam time ApplTime =  2ns;
-  localparam time TestTime =  8ns;
+  localparam realtime ClkPeriod = 10ns;
+  localparam realtime ApplTime =  2ns;
+  localparam realtime TestTime =  8ns;
 
-  localparam time JTAGPeriod = 50ns;
+  localparam realtime JTAGPeriod = 50ns;
 
   localparam int unsigned AW = 7;
   localparam logic [31:0] IDCode = 32'hdeadbeef | 32'd1;


### PR DESCRIPTION
Use realtime for testbench delay parameters so fractional clock and application/test delays are not rounded to integer time values.