### PR TITLE
dm: Fix multi-hart resume acknowledgement handling

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -51,3 +51,7 @@ sources:
   - target: dm_mem_test
     files:
     - tb/dm_mem/tb_dm_mem.sv
+
+  - target: multihart_resume_test
+    files:
+    - tb/dm_top/tb_dm_top_multihart_resume.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Keep accepted resume requests pending per hart until acknowledged and clear resumeack only for
   the request target; widen the internal dm_csrs/dm_mem clear_resumeack connection from scalar to
   a per-hart vector.
+- Make the write-only `dmcontrol.haltreq` field read as zero (#161).
 
 ## [0.10.1] - 2026-08-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Keep accepted resume requests pending per hart until acknowledged and clear resumeack only for
+  the request target; widen the internal dm_csrs/dm_mem clear_resumeack connection from scalar to
+  a per-hart vector.
+
 ## [0.10.1] - 2026-08-07
 ### Changed
 - Replace the obsolete Travis CI infrastructure with public GitHub Actions checks for licenses,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Fixed
-- Keep accepted resume requests pending per hart until acknowledged and clear resumeack only for
-  the request target; widen the internal dm_csrs/dm_mem clear_resumeack connection from scalar to
-  a per-hart vector.
+- Keep accepted resume requests pending per hart until acknowledged, clear resumeack only for the
+  request target, and retain resumeack across ndmreset; widen the internal dm_csrs/dm_mem
+  clear_resumeack connection from scalar to a per-hart vector and add a dmactive reset input to
+  dm_mem for resumeack state.
+- Reject out-of-range hart IDs reported through debug memory before updating per-hart state.
 - Make the write-only `dmcontrol.haltreq` field read as zero (#161).
 
 ## [0.10.1] - 2026-08-07

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -7,13 +7,27 @@
 
 ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
 TB := $(ROOT)/tb
+VERILATOR_FILE_LIST := $(ROOT)/build/verilator/sources.flist
 
 NUM_JOBS ?= 2
 OPENOCD_PREFIX ?= $(ROOT)/.cache/openocd
 
-.PHONY: all compliance dm-mem firmware full-model jtag-dmi openocd
+.PHONY: all compliance dm-mem firmware full-model jtag-dmi multihart-resume openocd \
+	verilator-sources
 
-all: dm-mem jtag-dmi compliance
+all: dm-mem jtag-dmi multihart-resume compliance
+
+verilator-sources:
+	cd $(ROOT) && bender checkout
+	mkdir -p $(dir $(VERILATOR_FILE_LIST))
+	cd $(ROOT) && bender script flist-plus \
+		--relative-path \
+		-t riscv-dbg:simulation \
+		-t riscv-dbg:test \
+		-t riscv-dbg:dm_mem_test \
+		-t riscv-dbg:multihart_resume_test \
+		-t tech_cells_generic:tech_cells_generic_exclude_deprecated \
+		> $(VERILATOR_FILE_LIST)
 
 full-model:
 	$(MAKE) -C $(TB) -j1 download_deps
@@ -26,13 +40,17 @@ openocd:
 	NUM_JOBS=$(NUM_JOBS) OPENOCD_PREFIX=$(OPENOCD_PREFIX) \
 		$(ROOT)/ci/get-openocd.sh
 
-jtag-dmi:
+jtag-dmi: verilator-sources
 	JTAG_BUILD_DIR=$(ROOT)/build/jtag-verilator \
 		$(ROOT)/ci/run-jtag-verilator.sh
 
-dm-mem:
+dm-mem: verilator-sources
 	DM_MEM_BUILD_DIR=$(ROOT)/build/dm-mem-verilator \
 		$(ROOT)/ci/run-dm-mem-verilator.sh
+
+multihart-resume: verilator-sources
+	MULTIHART_BUILD_DIR=$(ROOT)/build/multihart-verilator \
+		$(ROOT)/ci/run-multihart-verilator.sh
 
 compliance: full-model firmware openocd
 	cd $(TB) && \

--- a/ci/run-dm-mem-verilator.sh
+++ b/ci/run-dm-mem-verilator.sh
@@ -10,7 +10,6 @@ set -euo pipefail
 
 readonly ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly BUILD_DIR="${DM_MEM_BUILD_DIR:-${ROOT}/build/dm-mem-verilator}"
-readonly FILE_LIST="${BUILD_DIR}/sources.flist"
 
 # Fields: name BusWidth MaxRegisterAccessWidth HartSel AarSize ExpectSupported
 readonly TEST_CASES=(
@@ -23,34 +22,13 @@ readonly TEST_CASES=(
   "bus64_max64_aar64 64 64 1 3 1"
 )
 
-mkdir -p "${BUILD_DIR}"
-cd "${ROOT}"
-
-bender checkout
-bender script flist-plus \
-  --relative-path \
-  -t riscv-dbg:dm_mem_test \
-  -t tech_cells_generic:tech_cells_generic_exclude_deprecated \
-  > "${FILE_LIST}"
-
 for test_case in "${TEST_CASES[@]}"; do
   read -r name bus_width max_access_width hart_sel aar_size expect_supported <<< "${test_case}"
-  case_build_dir="${BUILD_DIR}/${name}"
-  mkdir -p "${case_build_dir}"
-
-  verilator \
-    --binary \
-    --timing \
-    -Wno-fatal \
-    -DCOMMON_CELLS_ASSERTS_OFF \
-    --top-module tb_dm_mem \
-    --Mdir "${case_build_dir}/obj_dir" \
+  "${ROOT}/ci/run-single-top-verilator.sh" \
+    "${BUILD_DIR}/${name}" tb_dm_mem \
     -GBusWidth="${bus_width}" \
     -GMaxRegisterAccessWidth="${max_access_width}" \
     -GHartSel="${hart_sel}" \
     -GAarSize="${aar_size}" \
-    -GExpectSupported="${expect_supported}" \
-    -f "${FILE_LIST}"
-
-  "${case_build_dir}/obj_dir/Vtb_dm_mem"
+    -GExpectSupported="${expect_supported}"
 done

--- a/ci/run-jtag-verilator.sh
+++ b/ci/run-jtag-verilator.sh
@@ -10,26 +10,7 @@ set -euo pipefail
 
 readonly ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly BUILD_DIR="${JTAG_BUILD_DIR:-${ROOT}/build/jtag-verilator}"
-readonly FILE_LIST="${BUILD_DIR}/sources.flist"
 
-mkdir -p "${BUILD_DIR}"
-cd "${ROOT}"
-
-bender checkout
-bender script flist-plus \
-  --relative-path \
-  -t riscv-dbg:simulation \
-  -t riscv-dbg:test \
-  -t tech_cells_generic:tech_cells_generic_exclude_deprecated \
-  > "${FILE_LIST}"
-
-verilator \
-  --binary \
-  --timing \
-  -Wno-fatal \
-  -DCOMMON_CELLS_ASSERTS_OFF \
-  --top-module tb_jtag_dmi \
-  --Mdir "${BUILD_DIR}/obj_dir" \
-  -f "${FILE_LIST}"
-
-"${BUILD_DIR}/obj_dir/Vtb_jtag_dmi"
+exec "${ROOT}/ci/run-single-top-verilator.sh" \
+  "${BUILD_DIR}" \
+  tb_jtag_dmi

--- a/ci/run-multihart-verilator.sh
+++ b/ci/run-multihart-verilator.sh
@@ -22,3 +22,11 @@ readonly BUILD_DIR="${MULTIHART_BUILD_DIR:-${ROOT}/build/multihart-verilator}"
 "${ROOT}/ci/run-single-top-verilator.sh" \
   "${BUILD_DIR}/four-hart" tb_dm_top_multihart_resume \
   -GNrHarts=4 -GSelectableHarts="4'b1111"
+
+"${ROOT}/ci/run-single-top-verilator.sh" \
+  "${BUILD_DIR}/five-hart" tb_dm_top_multihart_resume \
+  -GNrHarts=5 -GBusWidth=32 -GSelectableHarts="5'b11111"
+
+"${ROOT}/ci/run-single-top-verilator.sh" \
+  "${BUILD_DIR}/nine-hart" tb_dm_top_multihart_resume \
+  -GNrHarts=9 -GBusWidth=64 -GSelectableHarts="9'b111111111"

--- a/ci/run-multihart-verilator.sh
+++ b/ci/run-multihart-verilator.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Authors:
+# - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+set -euo pipefail
+
+readonly ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly BUILD_DIR="${MULTIHART_BUILD_DIR:-${ROOT}/build/multihart-verilator}"
+
+"${ROOT}/ci/run-single-top-verilator.sh" \
+  "${BUILD_DIR}/three-hart" tb_dm_top_multihart_resume \
+  -GNrHarts=3 -GSelectableHarts="3'b101"
+
+"${ROOT}/ci/run-single-top-verilator.sh" \
+  "${BUILD_DIR}/singleton" tb_dm_top_multihart_resume \
+  -GNrHarts=1 -GSelectableHarts="1'b1"
+
+"${ROOT}/ci/run-single-top-verilator.sh" \
+  "${BUILD_DIR}/four-hart" tb_dm_top_multihart_resume \
+  -GNrHarts=4 -GSelectableHarts="4'b1111"

--- a/ci/run-single-top-verilator.sh
+++ b/ci/run-single-top-verilator.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Authors:
+# - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+set -euo pipefail
+
+if (($# < 2)); then
+  echo "usage: $0 BUILD_DIR TOP_MODULE [VERILATOR_ARG ...]" >&2
+  exit 2
+fi
+
+readonly ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly BUILD_DIR="$(realpath -m -- "$1")"
+readonly TOP_MODULE="$2"
+shift 2
+readonly FILE_LIST="${ROOT}/build/verilator/sources.flist"
+
+if [[ ! -f "${FILE_LIST}" ]]; then
+  echo "error: Verilator file list not found: ${FILE_LIST}" >&2
+  echo "run 'make -C ci verilator-sources' first" >&2
+  exit 2
+fi
+
+mkdir -p "${BUILD_DIR}"
+cd "${ROOT}"
+
+verilator \
+  --binary \
+  --timing \
+  -Wno-fatal \
+  -DCOMMON_CELLS_ASSERTS_OFF \
+  --top-module "${TOP_MODULE}" \
+  --Mdir "${BUILD_DIR}/obj_dir" \
+  "$@" \
+  -f "${FILE_LIST}"
+
+"${BUILD_DIR}/obj_dir/V${TOP_MODULE}"

--- a/doc/debug-system.md
+++ b/doc/debug-system.md
@@ -88,7 +88,7 @@ Accessing a non-implemented register will return `0`.
 
 **Field**       | **Access** | **(Reset) Value** | **Comment**
 --------------- | ---------- | ----------------- | -------------------------------------------------------------------------------------------------------------
-haltreq         | WARZ
+haltreq         | W
 resumereq       | W1
 hartreset       | WARL       | 0                 | Not implemented, reads constant 0
 ackhavereset    | W1

--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -167,7 +167,7 @@ module dm_csrs #(
 
 
   dm::dmstatus_t      dmstatus;
-  dm::dmcontrol_t     dmcontrol_d, dmcontrol_q;
+  dm::dmcontrol_t     dmcontrol_d, dmcontrol_q, dmcontrol_read;
   dm::abstractcs_t    abstractcs;
   dm::cmderr_e        cmderr_d, cmderr_q;
   dm::command_t       command_d, command_q;
@@ -304,6 +304,9 @@ module dm_csrs #(
     // default assignments
     havereset_d         = havereset_q;
     dmcontrol_d         = dmcontrol_q;
+    dmcontrol_read      = dmcontrol_q;
+    dmcontrol_read.haltreq   = 1'b0;
+    dmcontrol_read.resumereq = 1'b0;
     resumereq_d         = resumereq_q;
     // Acknowledgements retire only the corresponding pending actions
     resumereq_d        &= ~resumeack_i;
@@ -341,7 +344,7 @@ module dm_csrs #(
             end
           end
         end
-        dm::DMControl:    resp_queue_inp.data = dmcontrol_q;
+        dm::DMControl:    resp_queue_inp.data = dmcontrol_read;
         dm::DMStatus:     resp_queue_inp.data = dmstatus;
         dm::Hartinfo:     resp_queue_inp.data = hartinfo_aligned[selected_hart];
         dm::AbstractCS:   resp_queue_inp.data = abstractcs;

--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -47,7 +47,8 @@ module dm_csrs #(
   output logic [19:0]                       hartsel_o,       // hartselect to ctrl module
   output logic [NrHarts-1:0]                haltreq_o,       // request to halt a hart
   output logic [NrHarts-1:0]                resumereq_o,     // request hart to resume
-  output logic                              clear_resumeack_o,
+  // Clears stale acknowledgements before issuing new resume requests
+  output logic [NrHarts-1:0]                clear_resumeack_o,
 
   output logic                              cmd_valid_o,       // debugger writing to cmd field
   output dm::command_t                      cmd_o,             // abstract command
@@ -85,6 +86,8 @@ module dm_csrs #(
   localparam int unsigned DataIndexWidth = $clog2(dm::DataCount);
   localparam int unsigned HartSelLen = (NrHarts == 1) ? 1 : $clog2(NrHarts);
   localparam int unsigned NrHartsAligned = 2**HartSelLen;
+  // Keep only the implemented WARL hart-select bits
+  localparam logic [19:0] HartSelMask = 20'((2**$clog2(NrHarts)) - 1);
 
   dm::dtm_op_e dtm_op;
   assign dtm_op = dm::dtm_op_e'(dmi_req_i.op);
@@ -175,6 +178,7 @@ module dm_csrs #(
   logic [63:0]        sbdata_d, sbdata_q;
 
   logic [NrHarts-1:0] havereset_d, havereset_q;
+  logic [NrHarts-1:0] resumereq_d, resumereq_q;
   // program buffer
   logic [dm::ProgBufSize-1:0][31:0] progbuf_d, progbuf_q;
   logic [dm::DataCount-1:0][31:0] data_d, data_d_dmi, data_q;
@@ -218,11 +222,39 @@ module dm_csrs #(
   dm::sbcs_t sbcs;
   logic [3:0] autoexecdata_idx; // 0 == Data0 ... 11 == Data11
 
+  // Decode immediate write effects independently of stored CSR state
+  logic [19:0]           dmcontrol_write_hartsel;
+  logic [HartSelLen-1:0] dmcontrol_write_hart;
+  logic                  dmcontrol_write_hart_valid;
+  logic                  dmcontrol_write_accepted;
+  logic                  dmcontrol_write_resumereq;
+  logic                  dmcontrol_write_haltreq;
+  logic                  dmcontrol_write_dmactive;
+
   // Get the data index, i.e. 0 for dm::Data0 up to 11 for dm::Data11
   assign dm_csr_addr = dm::dm_csr_e'({1'b0, dmi_req_i.addr});
   // Xilinx Vivado 2020.1 does not allow subtraction of two enums; do the subtraction with logic
   // types instead.
   assign autoexecdata_idx = 4'({dm_csr_addr} - {dm::Data0});
+
+  assign dmcontrol_write_hartsel = {dmi_req_i.data[15:6], dmi_req_i.data[25:16]}
+                                   & HartSelMask;
+  assign dmcontrol_write_hart = dmcontrol_write_hartsel[HartSelLen-1:0];
+  assign dmcontrol_write_hart_valid = dmcontrol_write_hartsel <= 20'(NrHarts - 1);
+  assign dmcontrol_write_accepted = dmi_req_ready_o && dmi_req_valid_i &&
+                                    dtm_op == dm::DTM_WRITE &&
+                                    dm_csr_addr == dm::DMControl;
+  assign dmcontrol_write_resumereq = dmcontrol_write_accepted && dmi_req_i.data[30];
+  assign dmcontrol_write_haltreq = dmi_req_i.data[31];
+  assign dmcontrol_write_dmactive = dmi_req_i.data[0];
+
+  always_comb begin : p_clear_resumeack
+    clear_resumeack_o = '0;
+    if (dmcontrol_write_resumereq && !dmcontrol_write_haltreq &&
+        dmcontrol_write_hart_valid && SelectableHarts[dmcontrol_write_hart]) begin
+      clear_resumeack_o[dmcontrol_write_hart] = 1'b1;
+    end
+  end
 
   always_comb (*xprop_off *) begin : csr_read_write
     // --------------------
@@ -272,6 +304,9 @@ module dm_csrs #(
     // default assignments
     havereset_d         = havereset_q;
     dmcontrol_d         = dmcontrol_q;
+    resumereq_d         = resumereq_q;
+    // Acknowledgements retire only the corresponding pending actions
+    resumereq_d        &= ~resumeack_i;
     cmderr_d            = cmderr_q;
     command_d           = command_q;
     progbuf_d           = progbuf_q;
@@ -286,7 +321,6 @@ module dm_csrs #(
     sbaddress_write_valid_o = 1'b0;
     sbdata_read_valid_o     = 1'b0;
     sbdata_write_valid_o    = 1'b0;
-    clear_resumeack_o       = 1'b0;
 
     // helper variables
     sbcs = '0;
@@ -540,15 +574,25 @@ module dm_csrs #(
     dmcontrol_d.zero0           = '0;
     // Non-writeable, clear only
     dmcontrol_d.ackhavereset    = 1'b0;
-    if (!dmcontrol_q.resumereq && dmcontrol_d.resumereq) begin
-      clear_resumeack_o = 1'b1;
+    // resumereq is W1/read-zero and is represented by the per-hart pending vector
+    dmcontrol_d.resumereq = 1'b0;
+
+    // Set a request only for an effective, selectable hart that is halted when
+    // the write is accepted. A new request wins over a same-cycle acknowledgement
+    if (dmcontrol_write_resumereq && dmcontrol_write_hart_valid &&
+        SelectableHarts[dmcontrol_write_hart] &&
+        halted_aligned[dmcontrol_write_hart] &&
+        !dmcontrol_write_haltreq) begin
+      resumereq_d[dmcontrol_write_hart] = 1'b1;
     end
-    if (dmcontrol_q.resumereq && resumeack_i) begin
-      dmcontrol_d.resumereq = 1'b0;
+
+    // Deactivating the debug module clears all pending actions
+    if (dmcontrol_write_accepted && !dmcontrol_write_dmactive) begin
+      resumereq_d = '0;
     end
     // WARL behavior of hartsel, depending on NrHarts.
     // If NrHarts = 1 this is just masked to all-zeros.
-    {dmcontrol_d.hartselhi, dmcontrol_d.hartsello} &= (2**$clog2(NrHarts))-1;
+    {dmcontrol_d.hartselhi, dmcontrol_d.hartsello} &= HartSelMask;
     // static values for dcsr
     sbcs_d.sbversion            = 3'd1;
     sbcs_d.sbbusy               = sbbusy_i;
@@ -567,10 +611,9 @@ module dm_csrs #(
   always_comb begin : p_outmux
     // default assignment
     haltreq_o = '0;
-    resumereq_o = '0;
+    resumereq_o = resumereq_q;
     if (selected_hart_valid) begin
       haltreq_o[selected_hart]   = dmcontrol_q.haltreq;
-      resumereq_o[selected_hart] = dmcontrol_q.resumereq;
     end
   end
 
@@ -618,6 +661,7 @@ module dm_csrs #(
       sbaddr_q       <= '0;
       sbdata_q       <= '0;
       havereset_q    <= '1;
+      resumereq_q    <= '0;
     end else begin
       havereset_q    <= SelectableHarts & havereset_d;
       // synchronous re-set of debug module, active-low, except for dmactive
@@ -634,6 +678,7 @@ module dm_csrs #(
         dmcontrol_q.setresethaltreq  <= '0;
         dmcontrol_q.clrresethaltreq  <= '0;
         dmcontrol_q.ndmreset         <= '0;
+        resumereq_q                  <= '0;
         // this is the only write-able bit during reset
         dmcontrol_q.dmactive         <= dmcontrol_d.dmactive;
         cmderr_q                     <= dm::CmdErrNone;
@@ -647,6 +692,7 @@ module dm_csrs #(
         sbdata_q                     <= '0;
       end else begin
         dmcontrol_q                  <= dmcontrol_d;
+        resumereq_q                  <= SelectableHarts & resumereq_d;
         cmderr_q                     <= cmderr_d;
         command_q                    <= command_d;
         cmd_valid_q                  <= cmd_valid_d;

--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -178,7 +178,7 @@ module dm_csrs #(
   logic [63:0]        sbdata_d, sbdata_q;
 
   logic [NrHarts-1:0] havereset_d, havereset_q;
-  logic [NrHarts-1:0] resumereq_d, resumereq_q;
+  logic [NrHarts-1:0] resume_pending_d, resume_pending_q;
   // program buffer
   logic [dm::ProgBufSize-1:0][31:0] progbuf_d, progbuf_q;
   logic [dm::DataCount-1:0][31:0] data_d, data_d_dmi, data_q;
@@ -307,9 +307,9 @@ module dm_csrs #(
     dmcontrol_read      = dmcontrol_q;
     dmcontrol_read.haltreq   = 1'b0;
     dmcontrol_read.resumereq = 1'b0;
-    resumereq_d         = resumereq_q;
+    resume_pending_d     = resume_pending_q;
     // Acknowledgements retire only the corresponding pending actions
-    resumereq_d        &= ~resumeack_i;
+    resume_pending_d    &= ~resumeack_i;
     cmderr_d            = cmderr_q;
     command_d           = command_q;
     progbuf_d           = progbuf_q;
@@ -585,13 +585,14 @@ module dm_csrs #(
     if (dmcontrol_write_resumereq && dmcontrol_write_hart_valid &&
         SelectableHarts[dmcontrol_write_hart] &&
         halted_aligned[dmcontrol_write_hart] &&
+        !unavailable_aligned[dmcontrol_write_hart] &&
         !dmcontrol_write_haltreq) begin
-      resumereq_d[dmcontrol_write_hart] = 1'b1;
+      resume_pending_d[dmcontrol_write_hart] = 1'b1;
     end
 
     // Deactivating the debug module clears all pending actions
     if (dmcontrol_write_accepted && !dmcontrol_write_dmactive) begin
-      resumereq_d = '0;
+      resume_pending_d = '0;
     end
     // WARL behavior of hartsel, depending on NrHarts.
     // If NrHarts = 1 this is just masked to all-zeros.
@@ -614,7 +615,7 @@ module dm_csrs #(
   always_comb begin : p_outmux
     // default assignment
     haltreq_o = '0;
-    resumereq_o = resumereq_q;
+    resumereq_o = resume_pending_q;
     if (selected_hart_valid) begin
       haltreq_o[selected_hart]   = dmcontrol_q.haltreq;
     end
@@ -664,7 +665,7 @@ module dm_csrs #(
       sbaddr_q       <= '0;
       sbdata_q       <= '0;
       havereset_q    <= '1;
-      resumereq_q    <= '0;
+      resume_pending_q <= '0;
     end else begin
       havereset_q    <= SelectableHarts & havereset_d;
       // synchronous re-set of debug module, active-low, except for dmactive
@@ -681,7 +682,7 @@ module dm_csrs #(
         dmcontrol_q.setresethaltreq  <= '0;
         dmcontrol_q.clrresethaltreq  <= '0;
         dmcontrol_q.ndmreset         <= '0;
-        resumereq_q                  <= '0;
+        resume_pending_q             <= '0;
         // this is the only write-able bit during reset
         dmcontrol_q.dmactive         <= dmcontrol_d.dmactive;
         cmderr_q                     <= dm::CmdErrNone;
@@ -695,7 +696,7 @@ module dm_csrs #(
         sbdata_q                     <= '0;
       end else begin
         dmcontrol_q                  <= dmcontrol_d;
-        resumereq_q                  <= SelectableHarts & resumereq_d;
+        resume_pending_q             <= SelectableHarts & resume_pending_d;
         cmderr_q                     <= cmderr_d;
         command_q                    <= command_d;
         cmd_valid_q                  <= cmd_valid_d;

--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -33,7 +33,8 @@ module dm_mem #(
   // from Ctrl and Status register
   input  logic [NrHarts-1:0]               haltreq_i,
   input  logic [NrHarts-1:0]               resumereq_i,
-  input  logic                             clear_resumeack_i,
+  // Clears stale acknowledgements before new resume requests
+  input  logic [NrHarts-1:0]               clear_resumeack_i,
 
   // state bits
   output logic [NrHarts-1:0]               halted_o,    // hart acknowledge halt
@@ -94,7 +95,7 @@ module dm_mem #(
   logic [7:0][63:0]   abstract_cmd;
   logic [NrHarts-1:0] halted_d, halted_q;
   logic [NrHarts-1:0] resuming_d, resuming_q;
-  logic               resume, go, going;
+  logic               go, going;
 
   logic exception;
   logic unsupported_command;
@@ -104,23 +105,21 @@ module dm_mem #(
   logic        word_enable32_q;
 
   logic [HartSelLen-1:0] hartsel, wdata_hartsel;
-  logic                  hartsel_valid, wdata_hartsel_valid;
+  logic                  wdata_hartsel_valid;
+  logic [DbgAddressBits-1:0] flags_hart_idx;
+  logic [HartSelLen-1:0] flags_hart;
 
   assign hartsel             = hartsel_i[HartSelLen-1:0];
   assign wdata_hartsel       = wdata_i[HartSelLen-1:0];
-  assign hartsel_valid       = hartsel <= HartSelLen'(NrHarts - 1);
   assign wdata_hartsel_valid = wdata_hartsel <= HartSelLen'(NrHarts - 1);
+  assign flags_hart_idx      = addr_i[DbgAddressBits-1:0] - FlagsBaseAddr;
+  assign flags_hart          = HartSelLen'(flags_hart_idx);
 
-  logic [NrHartsAligned-1:0] resumereq_aligned, haltreq_aligned,
-                             halted_q_aligned, halted_aligned,
-                             resumereq_wdata_aligned, resuming_q_aligned;
+  logic [NrHartsAligned-1:0] resumereq_aligned, halted_q_aligned, halted_aligned;
 
   assign resumereq_aligned       = NrHartsAligned'(resumereq_i);
-  assign haltreq_aligned         = NrHartsAligned'(haltreq_i);
-  assign resumereq_wdata_aligned = NrHartsAligned'(resumereq_i);
 
   assign halted_q_aligned        = NrHartsAligned'(halted_q);
-  assign resuming_q_aligned      = NrHartsAligned'(resuming_q);
 
   // distinguish whether we need to forward data from the ROM or the FSM
   // latch the address for this
@@ -145,7 +144,6 @@ module dm_mem #(
     cmderror_o       = dm::CmdErrNone;
     state_d          = state_q;
     go               = 1'b0;
-    resume           = 1'b0;
     cmdbusy_o        = 1'b1;
 
     unique case (state_q)
@@ -159,10 +157,8 @@ module dm_mem #(
           cmderror_valid_o = 1'b1;
           cmderror_o = dm::CmdErrorHaltResume;
         end
-        // CSRs want to resume, the request is ignored when the hart is
-        // requested to halt or it didn't clear the resuming_q bit before
-        if (resumereq_aligned[hartsel] && !resuming_q_aligned[hartsel] &&
-            !haltreq_aligned[hartsel] && halted_q_aligned[hartsel]) begin
+        // Enter the resume phase while any hart has a pending request
+        if (|resumereq_aligned) begin
           state_d = Resume;
         end
       end
@@ -179,8 +175,8 @@ module dm_mem #(
 
       Resume: begin
         cmdbusy_o = 1'b1;
-        resume = 1'b1;
-        if (resuming_q_aligned[hartsel]) begin
+        // Keep the resume phase active until every pending hart has completed
+        if (!(|resumereq_aligned)) begin
           state_d = Idle;
         end
       end
@@ -213,7 +209,6 @@ module dm_mem #(
       // Clear state of hart and its control signals when it is being reset.
       state_d = Idle;
       go      = 1'b0;
-      resume  = 1'b0;
     end
   end
 
@@ -260,13 +255,11 @@ module dm_mem #(
     data_o = data_bits;
   end
 
-  // Track resume acknowledgements. Memory writes take precedence over a clear request.
+  // Track resume acknowledgements with hart writes taking priority over clear requests
   always_comb begin : p_resuming
     resuming_d = resuming_q;
 
-    if (clear_resumeack_i && hartsel_valid) begin
-      resuming_d[hartsel] = 1'b0;
-    end
+    resuming_d &= ~clear_resumeack_i;
 
     if (req_i && we_i && addr_i[DbgAddressBits-1:0] == ResumingAddr &&
         wdata_hartsel_valid) begin
@@ -320,7 +313,7 @@ module dm_mem #(
           // variable ROM content
           WhereToAddr: begin
             // variable jump to abstract cmd, program_buffer or resume
-            if (resumereq_wdata_aligned[wdata_hartsel]) begin
+            if (resumereq_aligned[wdata_hartsel]) begin
               rdata_d = {32'b0, dm::jal('0, 21'(dm::ResumeAddress[11:0])-21'(WhereToAddr))};
             end
 
@@ -362,10 +355,13 @@ module dm_mem #(
           end
           // harts are polling for flags here
           [FlagsBaseAddr:FlagsEndAddr]: begin
-            // release the corresponding hart
-            if (({addr_i[DbgAddressBits-1:3], 3'b0} - FlagsBaseAddr[DbgAddressBits-1:0]) ==
-              (DbgAddressBits'(hartsel) & {{(DbgAddressBits-3){1'b1}}, 3'b0})) begin
-              rdata[DbgAddressBits'(hartsel) & DbgAddressBits'(3'b111)] = {6'b0, resume, go};
+            // Route resume by flag address and go to the active command hart
+            if (20'(flags_hart_idx) <= 20'(NrHarts - 1)) begin
+              rdata[addr_i[2:0]] = {
+                6'b0,
+                resumereq_aligned[flags_hart] && state_q == Resume && !ndmreset_i,
+                go && flags_hart == hartsel
+              };
             end
             rdata_d = rdata;
           end
@@ -566,8 +562,8 @@ module dm_mem #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      halted_q   <= 1'b0;
-      resuming_q <= 1'b0;
+      halted_q   <= '0;
+      resuming_q <= '0;
     end else begin
       halted_q   <= SelectableHarts & halted_d;
       resuming_q <= SelectableHarts & resuming_d;

--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -26,6 +26,7 @@ module dm_mem #(
 ) (
   input  logic                             clk_i,       // Clock
   input  logic                             rst_ni,      // debug module reset
+  input  logic                             dmactive_i,  // debug module is active
 
   output logic [NrHarts-1:0]               debug_req_o,
   input  logic                             ndmreset_i,
@@ -111,7 +112,7 @@ module dm_mem #(
 
   assign hartsel             = hartsel_i[HartSelLen-1:0];
   assign wdata_hartsel       = wdata_i[HartSelLen-1:0];
-  assign wdata_hartsel_valid = wdata_hartsel <= HartSelLen'(NrHarts - 1);
+  assign wdata_hartsel_valid = wdata_i[31:0] <= 32'(NrHarts - 1);
   assign flags_hart_idx      = addr_i[DbgAddressBits-1:0] - FlagsBaseAddr;
   assign flags_hart          = HartSelLen'(flags_hart_idx);
 
@@ -135,7 +136,7 @@ module dm_mem #(
   // reshape progbuf
   assign progbuf = progbuf_i;
 
-  typedef enum logic [1:0] { Idle, Go, Resume, CmdExecuting } state_e;
+  typedef enum logic [1:0] { Idle, Go, CmdExecuting } state_e;
   state_e state_d, state_q;
 
   // hart ctrl queue
@@ -157,10 +158,6 @@ module dm_mem #(
           cmderror_valid_o = 1'b1;
           cmderror_o = dm::CmdErrorHaltResume;
         end
-        // Enter the resume phase while any hart has a pending request
-        if (|resumereq_aligned) begin
-          state_d = Resume;
-        end
       end
 
       Go: begin
@@ -170,14 +167,6 @@ module dm_mem #(
         // the thread is now executing the command, track its state
         if (going) begin
             state_d = CmdExecuting;
-        end
-      end
-
-      Resume: begin
-        cmdbusy_o = 1'b1;
-        // Keep the resume phase active until every pending hart has completed
-        if (!(|resumereq_aligned)) begin
-          state_d = Idle;
         end
       end
 
@@ -266,7 +255,7 @@ module dm_mem #(
       resuming_d[wdata_hartsel] = 1'b1;
     end
 
-    if (ndmreset_i) begin
+    if (!dmactive_i) begin
       resuming_d = '0;
     end
   end
@@ -288,8 +277,8 @@ module dm_mem #(
       if (we_i) begin
         unique case (addr_i[DbgAddressBits-1:0]) inside
           HaltedAddr: begin
-            halted_aligned[wdata_hartsel] = 1'b1;
             if (wdata_hartsel_valid) begin
+              halted_aligned[wdata_hartsel] = 1'b1;
               halted_d[wdata_hartsel] = 1'b1;
             end
           end
@@ -313,7 +302,7 @@ module dm_mem #(
           // variable ROM content
           WhereToAddr: begin
             // variable jump to abstract cmd, program_buffer or resume
-            if (resumereq_aligned[wdata_hartsel]) begin
+            if (wdata_hartsel_valid && resumereq_aligned[wdata_hartsel]) begin
               rdata_d = {32'b0, dm::jal('0, 21'(dm::ResumeAddress[11:0])-21'(WhereToAddr))};
             end
 
@@ -359,8 +348,8 @@ module dm_mem #(
             if (20'(flags_hart_idx) <= 20'(NrHarts - 1)) begin
               rdata[addr_i[2:0]] = {
                 6'b0,
-                resumereq_aligned[flags_hart] && state_q == Resume && !ndmreset_i,
-                go && flags_hart == hartsel
+                resumereq_aligned[flags_hart] && dmactive_i && !ndmreset_i,
+                go && dmactive_i && flags_hart == hartsel
               };
             end
             rdata_d = rdata;

--- a/src/dm_mem.sv
+++ b/src/dm_mem.sv
@@ -150,7 +150,8 @@ module dm_mem #(
     unique case (state_q)
       Idle: begin
         cmdbusy_o = 1'b0;
-        if (cmd_valid_i && halted_q_aligned[hartsel] && !unsupported_command) begin
+        if (cmd_valid_i && halted_q_aligned[hartsel] &&
+            !resumereq_aligned[hartsel] && !unsupported_command) begin
           // give the go signal
           state_d = Go;
         end else if (cmd_valid_i) begin

--- a/src/dm_top.sv
+++ b/src/dm_top.sv
@@ -84,7 +84,7 @@ module dm_top #(
   logic [NrHarts-1:0]               resumeack;
   logic [NrHarts-1:0]               haltreq;
   logic [NrHarts-1:0]               resumereq;
-  logic                             clear_resumeack;
+  logic [NrHarts-1:0]               clear_resumeack;
   logic                             cmd_valid;
   dm::command_t                     cmd;
 

--- a/src/dm_top.sv
+++ b/src/dm_top.sv
@@ -214,6 +214,7 @@ module dm_top #(
   ) i_dm_mem (
     .clk_i,
     .rst_ni,
+    .dmactive_i              ( dmactive_o            ),
     .debug_req_o,
     .ndmreset_i              ( ndmreset              ),
     .hartsel_i               ( hartsel               ),

--- a/tb/dm_mem/tb_dm_mem.sv
+++ b/tb/dm_mem/tb_dm_mem.sv
@@ -64,6 +64,7 @@ module tb_dm_mem #(
   ) i_dm_mem (
     .clk_i                ( clk                    ),
     .rst_ni               ( rst_n                  ),
+    .dmactive_i           ( 1'b1                   ),
     .debug_req_o          (                        ),
     .ndmreset_i           ( 1'b0                   ),
     .hartsel_i            ( 20'(HartSel)            ),

--- a/tb/dm_mem/tb_dm_mem.sv
+++ b/tb/dm_mem/tb_dm_mem.sv
@@ -69,7 +69,7 @@ module tb_dm_mem #(
     .hartsel_i            ( 20'(HartSel)            ),
     .haltreq_i            ( '0                     ),
     .resumereq_i          ( '0                     ),
-    .clear_resumeack_i    ( 1'b0                   ),
+    .clear_resumeack_i    ( '0                     ),
     .halted_o             ( halted                 ),
     .resuming_o           (                        ),
     .progbuf_i            ( progbuf                ),

--- a/tb/dm_top/tb_dm_top_multihart_resume.sv
+++ b/tb/dm_top/tb_dm_top_multihart_resume.sv
@@ -1,0 +1,517 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors:
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+//
+// Checks multi-hart resume requests through the complete debug-module path
+// The default test uses three harts with a non-trivial selectable-hart mask
+// All variants drive both DMI DMControl and debug-memory Resuming writes
+
+module tb_dm_top_multihart_resume #(
+  parameter int unsigned NrHarts = 3,
+  parameter logic [NrHarts-1:0] SelectableHarts =
+      (NrHarts == 3) ? 3'b101 : {NrHarts{1'b1}}
+);
+
+  localparam logic [11:0] HaltedAddr   = 12'h100;
+  localparam logic [11:0] ResumingAddr = 12'h110;
+  localparam int unsigned HartOne = (NrHarts > 1) ? 1 : 0;
+  localparam int unsigned HartTwo = (NrHarts > 2) ? 2 : 0;
+  localparam int unsigned LastHart = NrHarts - 1;
+
+  logic clk, rst_n;
+
+  logic ndmreset, dmactive;
+
+  logic        slave_req, slave_we;
+  logic [31:0] slave_addr, slave_wdata;
+
+  logic dmi_req_valid, dmi_req_ready;
+  dm::dmi_req_t dmi_req;
+  logic dmi_resp_valid;
+  dm::dmi_resp_t dmi_resp;
+
+  initial begin
+    clk = 1'b0;
+    forever #5ns clk = ~clk;
+  end
+
+  dm_top #(
+    .NrHarts       ( NrHarts       ),
+    .BusWidth      ( 32            ),
+    .SelectableHarts ( SelectableHarts )
+  ) dut (
+    .clk_i                  ( clk             ),
+    .rst_ni                 ( rst_n           ),
+    .next_dm_addr_i         ( '0              ),
+    .testmode_i             ( 1'b0            ),
+    .ndmreset_o             ( ndmreset        ),
+    .ndmreset_ack_i         ( 1'b0            ),
+    .dmactive_o             ( dmactive        ),
+    .debug_req_o            (                 ),
+    .unavailable_i          ( '0              ),
+    .hartinfo_i             ( '0              ),
+    .slave_req_i            ( slave_req       ),
+    .slave_we_i             ( slave_we        ),
+    .slave_addr_i           ( slave_addr      ),
+    .slave_be_i             ( '1              ),
+    .slave_wdata_i          ( slave_wdata     ),
+    .slave_rdata_o          (                 ),
+    .master_req_o           (                 ),
+    .master_add_o           (                 ),
+    .master_we_o            (                 ),
+    .master_wdata_o         (                 ),
+    .master_be_o            (                 ),
+    .master_gnt_i           ( 1'b0            ),
+    .master_r_valid_i       ( 1'b0            ),
+    .master_r_err_i         ( 1'b0            ),
+    .master_r_other_err_i   ( 1'b0            ),
+    .master_r_rdata_i       ( '0              ),
+    .dmi_rst_ni             ( rst_n           ),
+    .dmi_req_valid_i        ( dmi_req_valid   ),
+    .dmi_req_ready_o        ( dmi_req_ready   ),
+    .dmi_req_i              ( dmi_req         ),
+    .dmi_resp_valid_o       ( dmi_resp_valid  ),
+    .dmi_resp_ready_i       ( 1'b1            ),
+    .dmi_resp_o             ( dmi_resp        )
+  );
+
+  task automatic write_dmcontrol(
+    input logic [19:0] hartsel,
+    input logic        request_resume,
+    input logic        request_ndmreset,
+    input logic        request_haltreq = 1'b0,
+    input logic        request_dmactive = 1'b1
+  );
+    dm::dmcontrol_t dmcontrol;
+
+    if (clk !== 1'b0) begin
+      @(negedge clk);
+    end
+    dmcontrol            = '0;
+    dmcontrol.hartsello  = hartsel[9:0];
+    dmcontrol.hartselhi  = hartsel[19:10];
+    dmcontrol.haltreq    = request_haltreq;
+    dmcontrol.resumereq  = request_resume;
+    dmcontrol.ndmreset   = request_ndmreset;
+    dmcontrol.dmactive   = request_dmactive;
+
+    while (!dmi_req_ready) begin
+      @(negedge clk);
+    end
+    dmi_req.data  = dmcontrol;
+    dmi_req_valid = 1'b1;
+    @(posedge clk);
+    if (!dmi_req_ready) begin
+      $fatal(1, "DMI request was not accepted");
+    end
+
+    @(negedge clk);
+    dmi_req_valid = 1'b0;
+    #1ns;
+    if (!dmi_resp_valid || dmi_resp.resp != dm::DTM_SUCCESS || dmi_resp.data != '0) begin
+      $fatal(1, "DMControl write for hartsel %0d failed (resp=%0d data=%08x)",
+             hartsel, dmi_resp.resp, dmi_resp.data);
+    end
+    // Let the response FIFO pop before issuing the next request
+    @(posedge clk);
+  endtask
+
+  task automatic expect_dmcontrol_resumereq_zero;
+    if (clk !== 1'b0) begin
+      @(negedge clk);
+    end
+    dmi_req.op    = dm::DTM_READ;
+    dmi_req_valid = 1'b1;
+    @(posedge clk);
+    if (!dmi_req_ready) begin
+      $fatal(1, "DMControl read was not accepted");
+    end
+    @(negedge clk);
+    dmi_req_valid = 1'b0;
+    #1ns;
+    if (!dmi_resp_valid || dmi_resp.resp != dm::DTM_SUCCESS ||
+        dmi_resp.data[30] !== 1'b0) begin
+      $fatal(1, "DMControl resumereq is not read-zero (data=%08x)", dmi_resp.data);
+    end
+    dmi_req.op = dm::DTM_WRITE;
+    @(posedge clk);
+  endtask
+
+  // Exercise memory-write-over-clear and ndmreset-over-clear/ack precedence
+  // by accepting the DMI write and ResumingAddr write on the same clock edge
+  task automatic write_dmcontrol_and_resuming(
+    input logic [19:0] hartsel,
+    input logic        request_resume,
+    input logic        request_ndmreset,
+    input int unsigned resuming_hart
+  );
+    dm::dmcontrol_t dmcontrol;
+
+    dmcontrol            = '0;
+    dmcontrol.hartsello  = hartsel[9:0];
+    dmcontrol.hartselhi  = hartsel[19:10];
+    dmcontrol.resumereq  = request_resume;
+    dmcontrol.ndmreset   = request_ndmreset;
+    dmcontrol.dmactive   = 1'b1;
+
+    @(negedge clk);
+    while (!dmi_req_ready) begin
+      @(negedge clk);
+    end
+    dmi_req.data  = dmcontrol;
+    dmi_req_valid = 1'b1;
+    slave_we      = 1'b1;
+    slave_req     = 1'b1;
+    slave_addr    = 32'(ResumingAddr);
+    slave_wdata   = 32'(resuming_hart);
+    @(posedge clk);
+    @(negedge clk);
+    dmi_req_valid = 1'b0;
+    slave_req     = 1'b0;
+    #1ns;
+    if (!dmi_resp_valid || dmi_resp.resp != dm::DTM_SUCCESS || dmi_resp.data != '0) begin
+      $fatal(1, "combined DMControl/ResumingAddr write failed");
+    end
+    @(posedge clk);
+  endtask
+
+  task automatic write_debug_memory(input logic [11:0] address, input int unsigned hart);
+    @(negedge clk);
+    slave_we    = 1'b1;
+    slave_req   = 1'b1;
+    slave_addr  = 32'(address);
+    slave_wdata = 32'(hart);
+    @(posedge clk);
+    @(negedge clk);
+    slave_req   = 1'b0;
+  endtask
+
+  task automatic read_debug_memory(input logic [11:0] address, output logic [31:0] data);
+    @(negedge clk);
+    slave_we    = 1'b0;
+    slave_req   = 1'b1;
+    slave_addr  = 32'(address);
+    slave_wdata = '0;
+    @(posedge clk);
+    #1ns;
+    data        = dut.slave_rdata_o;
+    @(negedge clk);
+    slave_req   = 1'b0;
+    slave_we    = 1'b1;
+  endtask
+
+  task automatic expect_resume_request(input int unsigned hart, input logic expected);
+    #1ns;
+    if (dut.resumereq[hart] !== expected) begin
+      $fatal(1, "resumereq[%0d]=%0b, expected %0b", hart, dut.resumereq[hart], expected);
+    end
+  endtask
+
+  task automatic expect_resume_ack(input int unsigned hart, input logic expected);
+    #1ns;
+    if (dut.resumeack[hart] !== expected) begin
+      $fatal(1, "resumeack[%0d]=%0b, expected %0b", hart, dut.resumeack[hart], expected);
+    end
+  endtask
+
+  task automatic expect_halted(input int unsigned hart, input logic expected);
+    #1ns;
+    if (dut.halted[hart] !== expected) begin
+      $fatal(1, "halted[%0d]=%0b, expected %0b", hart, dut.halted[hart], expected);
+    end
+  endtask
+
+  task automatic expect_resume_ack_vector(input logic [NrHarts-1:0] expected);
+    #1ns;
+    if (dut.resumeack !== expected) begin
+      $fatal(1, "resumeack=%b, expected %b", dut.resumeack, expected);
+    end
+  endtask
+
+  task automatic expect_resume_flag(input int unsigned hart, input logic expected);
+    logic [31:0] data;
+
+    read_debug_memory(12'(12'h400 + hart), data);
+    if (data[(hart & 3) * 8 + 1] !== expected) begin
+      $fatal(1, "resume flag[%0d]=%0b, expected %0b (data=%08x)",
+             hart, data[(hart & 3) * 8 + 1], expected, data);
+    end
+  endtask
+
+  task automatic expect_halted_vector(input logic [NrHarts-1:0] expected);
+    #1ns;
+    if (dut.halted !== expected) begin
+      $fatal(1, "halted=%b, expected %b", dut.halted, expected);
+    end
+  endtask
+
+  initial begin
+    logic [NrHarts-1:0] resumeack_before_invalid;
+    logic [NrHarts-1:0] expected_resumeack_before_ndmreset;
+
+    rst_n       = 1'b0;
+    slave_req   = 1'b0;
+    slave_we    = 1'b1;
+    slave_addr  = '0;
+    slave_wdata = '0;
+    dmi_req_valid = 1'b0;
+    dmi_req       = '0;
+    dmi_req.addr  = 7'(dm::DMControl);
+    dmi_req.op    = dm::DTM_WRITE;
+
+    repeat (3) @(posedge clk);
+    rst_n = 1'b1;
+    @(posedge clk);
+    #1ns;
+
+    // Activate the DM
+    write_dmcontrol(0, 1'b0, 1'b0);
+    if (!dmactive) begin
+      $fatal(1, "debug module did not become active");
+    end
+
+    if (NrHarts == 3) begin
+      // Harts 0 and 2 are selectable; hart 1 is intentionally masked out to
+      // exercise the non-trivial SelectableHarts parameter
+      // Leave hart 2's acknowledgement stale, then request hart 0
+      write_debug_memory(HaltedAddr, HartTwo);
+      write_debug_memory(ResumingAddr, HartTwo);
+      expect_resume_ack(HartTwo, 1'b1);
+      write_debug_memory(HaltedAddr, 0);
+      write_debug_memory(ResumingAddr, 0);
+      expect_resume_ack(0, 1'b1);
+      write_debug_memory(HaltedAddr, 0);
+      write_dmcontrol(0, 1'b1, 1'b0, 1'b1);
+      expect_resume_request(0, 1'b0);
+      expect_resume_ack(0, 1'b1);
+      write_dmcontrol(0, 1'b1, 1'b0);
+      expect_resume_request(0, 1'b1);
+      expect_resume_ack(HartTwo, 1'b1);
+
+      // Accept a second request without retiring the first one
+      write_debug_memory(HaltedAddr, HartTwo);
+      write_dmcontrol(20'(HartTwo), 1'b1, 1'b0);
+      expect_resume_request(HartTwo, 1'b1);
+      expect_resume_request(0, 1'b1);
+      expect_resume_ack(HartTwo, 1'b0);
+      // A non-requesting write changes hartsel but cannot cancel either action
+      write_dmcontrol(20'(HartTwo), 1'b0, 1'b0);
+      expect_dmcontrol_resumereq_zero();
+      expect_resume_flag(0, 1'b1);
+      expect_resume_flag(HartTwo, 1'b1);
+
+      // Acknowledge the two harts independently
+      write_debug_memory(ResumingAddr, HartTwo);
+      expect_resume_ack(HartTwo, 1'b1);
+      @(posedge clk);
+      expect_resume_request(HartTwo, 1'b0);
+      expect_resume_request(0, 1'b1);
+      expect_resume_flag(0, 1'b1);
+      write_debug_memory(ResumingAddr, 0);
+      @(posedge clk);
+      expect_resume_request(0, 1'b0);
+      expect_resume_request(HartTwo, 1'b0);
+
+      // A stale acknowledgement is cleared for the effective target
+      write_debug_memory(HaltedAddr, 0);
+      write_debug_memory(ResumingAddr, 0);
+      expect_resume_ack(0, 1'b1);
+      write_debug_memory(HaltedAddr, 0);
+      write_dmcontrol(20'd0, 1'b1, 1'b0);
+      expect_resume_request(0, 1'b1);
+      expect_resume_ack(0, 1'b0);
+
+      // A memory acknowledgement on the same edge as a new request's clear
+      // must win over the clear, leaving resumeack set for completion
+      write_dmcontrol_and_resuming(20'd0, 1'b1, 1'b0, 0);
+      expect_resume_ack(0, 1'b1);
+      expect_resume_request(0, 1'b0);
+
+      // Raw hartsel=4 is WARL-masked to hart 0 for NrHarts=3.  A stale
+      // acknowledgement must be cleared for the effective target, and the
+      // resulting request must remain outstanding until a fresh acknowledgement
+      write_debug_memory(HaltedAddr, 0);
+      write_dmcontrol(20'd4, 1'b1, 1'b0);
+      expect_resume_request(0, 1'b1);
+      expect_resume_ack(0, 1'b0);
+      write_debug_memory(ResumingAddr, 0);
+      @(posedge clk);
+      expect_resume_request(0, 1'b0);
+
+      // Raw hartsel=3 is effective-invalid for NrHarts=3.  It must neither
+      // clear an acknowledgement nor create a request for any valid hart
+      expect_resume_ack(HartTwo, 1'b1);
+      resumeack_before_invalid = dut.resumeack;
+      write_dmcontrol(20'd3, 1'b1, 1'b0);
+      if (dut.resumeack !== resumeack_before_invalid || dut.resumereq !== '0) begin
+        $fatal(1, "invalid hartsel changed per-hart resume state");
+      end
+      // Recover from the invalid selection with a valid, non-requesting write
+      write_dmcontrol(0, 1'b0, 1'b0);
+      if (dut.resumereq !== '0 || dut.resumeack !== resumeack_before_invalid) begin
+        $fatal(1, "invalid hartsel recovery changed resume state");
+      end
+
+      // Hart 1 is masked out, so its request and acknowledgement are ignored
+      write_debug_memory(HaltedAddr, HartOne);
+      write_dmcontrol(20'(HartOne), 1'b1, 1'b0);
+      expect_resume_request(HartOne, 1'b0);
+      expect_resume_ack(0, 1'b1);
+      write_debug_memory(ResumingAddr, HartOne);
+      expect_resume_ack(HartOne, 1'b0);
+      expect_resume_ack(0, 1'b1);
+
+      // Deactivating the debug module clears all pending actions
+      write_debug_memory(HaltedAddr, HartTwo);
+      write_dmcontrol(20'(HartTwo), 1'b1, 1'b0);
+      expect_resume_request(HartTwo, 1'b1);
+      write_dmcontrol(20'(HartTwo), 1'b0, 1'b0, 1'b0, 1'b0);
+      if (dmactive || dut.resumereq !== '0) begin
+        $fatal(1, "DM deactivation retained resume state");
+      end
+      write_dmcontrol(0, 1'b0, 1'b0);
+      if (!dmactive) begin
+        $fatal(1, "debug module did not reactivate");
+      end
+
+      // Keep a request outstanding across ndmreset.  dm_mem clears its halted,
+      // resuming, and FSM state, while dm_csrs retains the pending action
+      write_debug_memory(HaltedAddr, HartTwo);
+      write_dmcontrol(20'(HartTwo), 1'b1, 1'b0);
+      expect_resume_request(HartTwo, 1'b1);
+      write_dmcontrol(20'(HartTwo), 1'b1, 1'b1);
+      @(posedge clk);
+      #1ns;
+      if (!ndmreset) begin
+        $fatal(1, "ndmreset did not assert");
+      end
+      expect_halted(HartTwo, 1'b0);
+      expect_resume_ack(HartTwo, 1'b0);
+      expect_resume_request(HartTwo, 1'b1);
+
+      // Deassert ndmreset, re-establish halted state, and complete the retained
+      // request. The concurrent ResumingAddr write is suppressed by ndmreset
+      write_dmcontrol_and_resuming(20'(HartTwo), 1'b1, 1'b0, HartTwo);
+      if (ndmreset) begin
+        $fatal(1, "ndmreset did not deassert");
+      end
+      expect_resume_ack(HartTwo, 1'b0);
+      write_debug_memory(HaltedAddr, HartTwo);
+      expect_halted(HartTwo, 1'b1);
+      write_debug_memory(ResumingAddr, HartTwo);
+      expect_resume_ack(HartTwo, 1'b1);
+      @(posedge clk);
+      expect_resume_request(HartTwo, 1'b0);
+    end else if (NrHarts == 1) begin
+      // The singleton case still exercises stale-ack clearing and normal
+      // request completion before checking the full-vector reset behavior
+      write_debug_memory(HaltedAddr, 0);
+      write_debug_memory(ResumingAddr, 0);
+      expect_resume_ack(0, 1'b1);
+      write_debug_memory(HaltedAddr, 0);
+      write_dmcontrol(0, 1'b1, 1'b0);
+      expect_resume_ack(0, 1'b0);
+      expect_resume_request(0, 1'b1);
+      write_debug_memory(ResumingAddr, 0);
+      expect_resume_ack(0, 1'b1);
+      @(posedge clk);
+      expect_resume_request(0, 1'b0);
+
+      write_debug_memory(HaltedAddr, 0);
+      write_debug_memory(ResumingAddr, 0);
+      write_debug_memory(HaltedAddr, 0);
+      expect_halted_vector('1);
+      expect_resume_ack_vector('1);
+      write_dmcontrol(0, 1'b1, 1'b1);
+      @(posedge clk);
+      #1ns;
+      if (!ndmreset) begin
+        $fatal(1, "singleton ndmreset did not assert");
+      end
+      expect_halted_vector('0);
+      expect_resume_ack_vector('0);
+      write_dmcontrol(0, 1'b0, 1'b0);
+      if (ndmreset) begin
+        $fatal(1, "singleton ndmreset did not deassert");
+      end
+      expect_halted_vector('0);
+      expect_resume_ack_vector('0);
+    end else if (NrHarts == 4) begin
+      // Power-of-two hart selection must preserve an unrelated stale
+      // acknowledgement and support same-edge clear/ack traffic
+      write_debug_memory(HaltedAddr, 0);
+      write_debug_memory(HaltedAddr, LastHart);
+      write_debug_memory(ResumingAddr, 0);
+      write_debug_memory(ResumingAddr, LastHart);
+      expect_resume_ack(0, 1'b1);
+      expect_resume_ack(LastHart, 1'b1);
+
+      write_debug_memory(HaltedAddr, 0);
+      write_dmcontrol(0, 1'b1, 1'b0);
+      expect_resume_request(0, 1'b1);
+      expect_resume_ack(0, 1'b0);
+      expect_resume_ack(LastHart, 1'b1);
+
+      write_debug_memory(ResumingAddr, 0);
+      expect_resume_ack(0, 1'b1);
+      @(posedge clk);
+      expect_resume_request(0, 1'b0);
+      write_debug_memory(HaltedAddr, 0);
+      write_debug_memory(HaltedAddr, LastHart);
+      write_dmcontrol(20'(LastHart), 1'b1, 1'b0);
+      expect_resume_request(LastHart, 1'b1);
+      expect_resume_ack(LastHart, 1'b0);
+      expect_resume_ack(0, 1'b1);
+
+      // Clear hart 0 while acknowledging hart 3 on the same edge.  The
+      // cross-hart effects must remain independent
+      write_dmcontrol_and_resuming(20'd0, 1'b1, 1'b0, LastHart);
+      expect_resume_ack(0, 1'b0);
+      expect_resume_ack(LastHart, 1'b1);
+      expect_resume_request(0, 1'b1);
+      write_debug_memory(ResumingAddr, 0);
+      expect_resume_ack(0, 1'b1);
+      @(posedge clk);
+      expect_resume_request(0, 1'b0);
+
+      // Set every halted bit so ndmreset must clear the complete vector
+      write_debug_memory(HaltedAddr, 0);
+      write_debug_memory(HaltedAddr, 1);
+      write_debug_memory(HaltedAddr, 2);
+      write_debug_memory(HaltedAddr, LastHart);
+      expect_halted_vector('1);
+      expected_resumeack_before_ndmreset = '0;
+      expected_resumeack_before_ndmreset[0] = 1'b1;
+      expected_resumeack_before_ndmreset[LastHart] = 1'b1;
+      expect_resume_ack_vector(expected_resumeack_before_ndmreset);
+      write_dmcontrol(0, 1'b1, 1'b1);
+      @(posedge clk);
+      #1ns;
+      if (!ndmreset) begin
+        $fatal(1, "four-hart ndmreset did not assert");
+      end
+      expect_halted_vector('0);
+      expect_resume_ack_vector('0);
+      write_dmcontrol(0, 1'b0, 1'b0);
+      if (ndmreset) begin
+        $fatal(1, "four-hart ndmreset did not deassert");
+      end
+      expect_halted_vector('0);
+      expect_resume_ack_vector('0);
+    end else begin
+      $fatal(1, "unsupported NrHarts=%0d", NrHarts);
+    end
+
+    $display("tb_dm_top_multihart_resume: passed");
+    $finish;
+  end
+
+  initial begin
+    #5us;
+    $fatal(1, "tb_dm_top_multihart_resume: timeout");
+  end
+
+endmodule

--- a/tb/dm_top/tb_dm_top_multihart_resume.sv
+++ b/tb/dm_top/tb_dm_top_multihart_resume.sv
@@ -11,22 +11,30 @@
 
 module tb_dm_top_multihart_resume #(
   parameter int unsigned NrHarts = 3,
+  parameter int unsigned BusWidth = 32,
   parameter logic [NrHarts-1:0] SelectableHarts =
       (NrHarts == 3) ? 3'b101 : {NrHarts{1'b1}}
 );
 
   localparam logic [11:0] HaltedAddr   = 12'h100;
+  localparam logic [11:0] GoingAddr    = 12'h108;
   localparam logic [11:0] ResumingAddr = 12'h110;
   localparam int unsigned HartOne = (NrHarts > 1) ? 1 : 0;
   localparam int unsigned HartTwo = (NrHarts > 2) ? 2 : 0;
   localparam int unsigned LastHart = NrHarts - 1;
+  localparam int unsigned HartSelLen = (NrHarts == 1) ? 1 : $clog2(NrHarts);
+  localparam int unsigned InvalidDebugHart = 2**HartSelLen;
+  localparam int unsigned HartsPerFlagWord = BusWidth / 8;
+  localparam logic [BusWidth-1:0] InactiveUpperWdata = BusWidth'(64'hdead_beef_0000_0000);
 
   logic clk, rst_n;
 
   logic ndmreset, dmactive;
 
   logic        slave_req, slave_we;
-  logic [31:0] slave_addr, slave_wdata;
+  logic [BusWidth-1:0] slave_addr, slave_wdata;
+  logic [BusWidth/8-1:0] slave_be;
+  logic [NrHarts-1:0] unavailable_i;
 
   logic dmi_req_valid, dmi_req_ready;
   dm::dmi_req_t dmi_req;
@@ -39,8 +47,8 @@ module tb_dm_top_multihart_resume #(
   end
 
   dm_top #(
-    .NrHarts       ( NrHarts       ),
-    .BusWidth      ( 32            ),
+    .NrHarts        ( NrHarts        ),
+    .BusWidth       ( BusWidth       ),
     .SelectableHarts ( SelectableHarts )
   ) dut (
     .clk_i                  ( clk             ),
@@ -51,12 +59,12 @@ module tb_dm_top_multihart_resume #(
     .ndmreset_ack_i         ( 1'b0            ),
     .dmactive_o             ( dmactive        ),
     .debug_req_o            (                 ),
-    .unavailable_i          ( '0              ),
+    .unavailable_i          ( unavailable_i   ),
     .hartinfo_i             ( '0              ),
     .slave_req_i            ( slave_req       ),
     .slave_we_i             ( slave_we        ),
     .slave_addr_i           ( slave_addr      ),
-    .slave_be_i             ( '1              ),
+    .slave_be_i             ( slave_be        ),
     .slave_wdata_i          ( slave_wdata     ),
     .slave_rdata_o          (                 ),
     .master_req_o           (                 ),
@@ -87,9 +95,6 @@ module tb_dm_top_multihart_resume #(
   );
     dm::dmcontrol_t dmcontrol;
 
-    if (clk !== 1'b0) begin
-      @(negedge clk);
-    end
     dmcontrol            = '0;
     dmcontrol.hartsello  = hartsel[9:0];
     dmcontrol.hartselhi  = hartsel[19:10];
@@ -97,26 +102,114 @@ module tb_dm_top_multihart_resume #(
     dmcontrol.resumereq  = request_resume;
     dmcontrol.ndmreset   = request_ndmreset;
     dmcontrol.dmactive   = request_dmactive;
+    write_dmi(8'(dm::DMControl), dmcontrol);
+  endtask
 
+  task automatic write_dmi(input logic [7:0] address, input logic [31:0] data);
+    if (clk !== 1'b0) begin
+      @(negedge clk);
+    end
     while (!dmi_req_ready) begin
       @(negedge clk);
     end
-    dmi_req.data  = dmcontrol;
+    dmi_req.addr  = address[6:0];
+    dmi_req.op    = dm::DTM_WRITE;
+    dmi_req.data  = data;
     dmi_req_valid = 1'b1;
     @(posedge clk);
     if (!dmi_req_ready) begin
-      $fatal(1, "DMI request was not accepted");
+      $fatal(1, "DMI write was not accepted");
     end
-
     @(negedge clk);
     dmi_req_valid = 1'b0;
     #1ns;
     if (!dmi_resp_valid || dmi_resp.resp != dm::DTM_SUCCESS || dmi_resp.data != '0) begin
-      $fatal(1, "DMControl write for hartsel %0d failed (resp=%0d data=%08x)",
-             hartsel, dmi_resp.resp, dmi_resp.data);
+      $fatal(1, "DMI write to %02x failed (resp=%0d data=%08x)",
+             address, dmi_resp.resp, dmi_resp.data);
     end
-    // Let the response FIFO pop before issuing the next request
     @(posedge clk);
+  endtask
+
+  task automatic read_dmi(input logic [7:0] address, output logic [31:0] data);
+    if (clk !== 1'b0) begin
+      @(negedge clk);
+    end
+    while (!dmi_req_ready) begin
+      @(negedge clk);
+    end
+    dmi_req.addr  = address[6:0];
+    dmi_req.op    = dm::DTM_READ;
+    dmi_req.data  = '0;
+    dmi_req_valid = 1'b1;
+    @(posedge clk);
+    if (!dmi_req_ready) begin
+      $fatal(1, "DMI read was not accepted");
+    end
+    @(negedge clk);
+    dmi_req_valid = 1'b0;
+    #1ns;
+    if (!dmi_resp_valid || dmi_resp.resp != dm::DTM_SUCCESS) begin
+      $fatal(1, "DMI read from %02x failed (resp=%0d)", address, dmi_resp.resp);
+    end
+    data = dmi_resp.data;
+    @(posedge clk);
+  endtask
+
+  task automatic execute_access_register_command(input int unsigned command_hart);
+    logic [BusWidth-1:0] flags_data;
+    logic [31:0] abstractcs_data;
+    dm::abstractcs_t abstractcs;
+    dm::ac_ar_cmd_t access_register;
+    dm::command_t command;
+    bit command_retired;
+
+    access_register            = '0;
+    access_register.aarsize   = 3'd2;
+    access_register.transfer  = 1'b1;
+    access_register.regno     = 16'h1001;
+    command                   = '0;
+    command.cmdtype           = dm::AccessRegister;
+    command.control           = access_register;
+    write_dmcontrol(20'(command_hart), 1'b0, 1'b0);
+    write_dmi(8'(dm::Command), command);
+
+    read_dmi(8'(dm::AbstractCS), abstractcs_data);
+    abstractcs = dm::abstractcs_t'(abstractcs_data);
+    if (!abstractcs.busy) begin
+      $fatal(1, "access register command for hart %0d was lost while a resume was pending",
+             command_hart);
+    end
+
+    // The hart observes Go before reporting that it is going
+    read_debug_memory(12'(12'h400 + command_hart), flags_data);
+    if (flags_data[(command_hart % HartsPerFlagWord) * 8] !== 1'b1) begin
+      $fatal(1, "Go flag[%0d] was not asserted (data=%08x)", command_hart, flags_data);
+    end
+    write_debug_memory(GoingAddr, 0);
+    read_dmi(8'(dm::AbstractCS), abstractcs_data);
+    abstractcs = dm::abstractcs_t'(abstractcs_data);
+    if (!abstractcs.busy) begin
+      $fatal(1, "abstract command did not remain busy after Going for hart %0d", command_hart);
+    end
+
+    // The hart returns to Halted, retiring the command
+    write_debug_memory(HaltedAddr, command_hart);
+    command_retired = 1'b0;
+    repeat (8) begin
+      read_dmi(8'(dm::AbstractCS), abstractcs_data);
+      abstractcs = dm::abstractcs_t'(abstractcs_data);
+      if (!abstractcs.busy) begin
+        command_retired = 1'b1;
+        break;
+      end
+    end
+    if (!command_retired) begin
+      $fatal(1, "abstract command for hart %0d did not retire", command_hart);
+    end
+    if (abstractcs.cmderr != dm::CmdErrNone) begin
+      $fatal(1, "abstract command for hart %0d retired with cmderr %0d",
+             command_hart, abstractcs.cmderr);
+    end
   endtask
 
   task automatic expect_dmcontrol_write_only_fields_zero;
@@ -161,12 +254,15 @@ module tb_dm_top_multihart_resume #(
     while (!dmi_req_ready) begin
       @(negedge clk);
     end
+    dmi_req.addr = 7'(dm::DMControl);
+    dmi_req.op    = dm::DTM_WRITE;
     dmi_req.data  = dmcontrol;
     dmi_req_valid = 1'b1;
     slave_we      = 1'b1;
     slave_req     = 1'b1;
-    slave_addr    = 32'(ResumingAddr);
-    slave_wdata   = 32'(resuming_hart);
+    slave_addr    = BusWidth'(ResumingAddr);
+    slave_wdata   = BusWidth'(resuming_hart);
+    slave_be      = '1;
     @(posedge clk);
     @(negedge clk);
     dmi_req_valid = 1'b0;
@@ -178,23 +274,31 @@ module tb_dm_top_multihart_resume #(
     @(posedge clk);
   endtask
 
-  task automatic write_debug_memory(input logic [11:0] address, input int unsigned hart);
+  task automatic write_debug_memory(
+    input logic [11:0]             address,
+    input int unsigned             hart,
+    input logic [BusWidth-1:0]     inactive_wdata = '0
+  );
     @(negedge clk);
     slave_we    = 1'b1;
     slave_req   = 1'b1;
-    slave_addr  = 32'(address);
-    slave_wdata = 32'(hart);
+    slave_addr  = BusWidth'(address);
+    slave_wdata = BusWidth'(hart) | inactive_wdata;
+    slave_be      = '0;
+    slave_be[3:0] = 4'hf;
     @(posedge clk);
     @(negedge clk);
     slave_req   = 1'b0;
   endtask
 
-  task automatic read_debug_memory(input logic [11:0] address, output logic [31:0] data);
+  task automatic read_debug_memory(input logic [11:0] address,
+                                   output logic [BusWidth-1:0] data);
     @(negedge clk);
     slave_we    = 1'b0;
     slave_req   = 1'b1;
-    slave_addr  = 32'(address);
+    slave_addr  = BusWidth'(address);
     slave_wdata = '0;
+    slave_be    = '0;
     @(posedge clk);
     #1ns;
     data        = dut.slave_rdata_o;
@@ -232,12 +336,12 @@ module tb_dm_top_multihart_resume #(
   endtask
 
   task automatic expect_resume_flag(input int unsigned hart, input logic expected);
-    logic [31:0] data;
+    logic [BusWidth-1:0] data;
 
     read_debug_memory(12'(12'h400 + hart), data);
-    if (data[(hart & 3) * 8 + 1] !== expected) begin
+    if (data[(hart % HartsPerFlagWord) * 8 + 1] !== expected) begin
       $fatal(1, "resume flag[%0d]=%0b, expected %0b (data=%08x)",
-             hart, data[(hart & 3) * 8 + 1], expected, data);
+             hart, data[(hart % HartsPerFlagWord) * 8 + 1], expected, data);
     end
   endtask
 
@@ -246,6 +350,51 @@ module tb_dm_top_multihart_resume #(
     if (dut.halted !== expected) begin
       $fatal(1, "halted=%b, expected %b", dut.halted, expected);
     end
+  endtask
+
+  task automatic check_invalid_debug_hart;
+    logic [NrHarts-1:0] halted_before;
+    logic [NrHarts-1:0] resumeack_before;
+    logic [NrHarts-1:0] resumereq_before;
+
+    // Exercise halted, acknowledged, and pending hart 0 states
+    write_debug_memory(HaltedAddr, 0);
+    write_debug_memory(ResumingAddr, 0);
+    expect_halted(0, 1'b0);
+    expect_resume_ack(0, 1'b1);
+    halted_before    = dut.halted;
+    resumeack_before = dut.resumeack;
+    resumereq_before = dut.resumereq;
+    write_debug_memory(HaltedAddr, InvalidDebugHart);
+    if (dut.halted !== halted_before || dut.resumeack !== resumeack_before ||
+        dut.resumereq !== resumereq_before) begin
+      $fatal(1, "invalid HaltedAddr hart %0d changed valid hart state", InvalidDebugHart);
+    end
+
+    if (NrHarts == 9 && BusWidth == 64) begin
+      // 64-bit ROM stores carry only the lower 32-bit hart ID
+      write_debug_memory(HaltedAddr, 0, InactiveUpperWdata);
+      expect_halted(0, 1'b1);
+      write_debug_memory(ResumingAddr, 0, InactiveUpperWdata);
+      expect_halted(0, 1'b0);
+      expect_resume_ack(0, 1'b1);
+    end
+
+    write_debug_memory(HaltedAddr, 0);
+    write_dmcontrol(0, 1'b1, 1'b0);
+    expect_halted(0, 1'b1);
+    expect_resume_ack(0, 1'b0);
+    expect_resume_request(0, 1'b1);
+    halted_before    = dut.halted;
+    resumeack_before = dut.resumeack;
+    resumereq_before = dut.resumereq;
+    write_debug_memory(ResumingAddr, InvalidDebugHart);
+    if (dut.halted !== halted_before || dut.resumeack !== resumeack_before ||
+        dut.resumereq !== resumereq_before) begin
+      $fatal(1, "invalid ResumingAddr hart %0d changed valid hart state", InvalidDebugHart);
+    end
+
+    write_debug_memory(ResumingAddr, 0);
   endtask
 
   initial begin
@@ -257,6 +406,8 @@ module tb_dm_top_multihart_resume #(
     slave_we    = 1'b1;
     slave_addr  = '0;
     slave_wdata = '0;
+    slave_be    = '0;
+    unavailable_i = '0;
     dmi_req_valid = 1'b0;
     dmi_req       = '0;
     dmi_req.addr  = 7'(dm::DMControl);
@@ -273,9 +424,34 @@ module tb_dm_top_multihart_resume #(
       $fatal(1, "debug module did not become active");
     end
 
+    if (NrHarts == 3 || NrHarts >= 5) begin
+      check_invalid_debug_hart();
+    end
+
     if (NrHarts == 3) begin
       // Harts 0 and 2 are selectable; hart 1 is intentionally masked out to
       // exercise the non-trivial SelectableHarts parameter
+      // A stale halted cache must not create a request for an unavailable hart
+      write_debug_memory(HaltedAddr, HartTwo);
+      write_debug_memory(ResumingAddr, HartTwo);
+      write_debug_memory(HaltedAddr, HartTwo);
+      unavailable_i[HartTwo] = 1'b1;
+      write_dmcontrol(20'(HartTwo), 1'b1, 1'b0);
+      expect_resume_request(HartTwo, 1'b0);
+      expect_resume_flag(HartTwo, 1'b0);
+      expect_resume_ack(HartTwo, 1'b0);
+      begin
+        logic [31:0] status_data;
+        dm::dmstatus_t status;
+        read_dmi(8'(dm::DMStatus), status_data);
+        status = dm::dmstatus_t'(status_data);
+        if (!status.allunavail || !status.anyunavail || status.allhalted ||
+            status.anyhalted || status.allresumeack || status.anyresumeack) begin
+          $fatal(1, "DMStatus did not report unavailable hart %0d correctly", HartTwo);
+        end
+      end
+      unavailable_i[HartTwo] = 1'b0;
+
       // Leave hart 2's acknowledgement stale, then request hart 0
       write_debug_memory(HaltedAddr, HartTwo);
       write_debug_memory(ResumingAddr, HartTwo);
@@ -294,6 +470,11 @@ module tb_dm_top_multihart_resume #(
       write_dmcontrol(0, 1'b1, 1'b0);
       expect_resume_request(0, 1'b1);
       expect_resume_ack(HartTwo, 1'b1);
+
+      // A pending resume for hart 0 must not block a command for hart 2
+      write_debug_memory(HaltedAddr, HartTwo);
+      execute_access_register_command(HartTwo);
+      expect_resume_request(0, 1'b1);
 
       // Accept a second request without retiring the first one
       write_debug_memory(HaltedAddr, HartTwo);
@@ -368,7 +549,8 @@ module tb_dm_top_multihart_resume #(
       expect_resume_ack(HartOne, 1'b0);
       expect_resume_ack(0, 1'b1);
 
-      // Deactivating the debug module clears all pending actions
+      // Deactivating the debug module clears acknowledgements and pending actions
+      expect_resume_ack(0, 1'b1);
       write_debug_memory(HaltedAddr, HartTwo);
       write_dmcontrol(20'(HartTwo), 1'b1, 1'b0);
       expect_resume_request(HartTwo, 1'b1);
@@ -376,42 +558,55 @@ module tb_dm_top_multihart_resume #(
       if (dmactive || dut.resumereq !== '0) begin
         $fatal(1, "DM deactivation retained resume state");
       end
+      expect_resume_flag(HartTwo, 1'b0);
+      expect_resume_ack(0, 1'b0);
+      expect_resume_ack(HartTwo, 1'b0);
       write_dmcontrol(0, 1'b0, 1'b0);
       if (!dmactive) begin
         $fatal(1, "debug module did not reactivate");
       end
 
-      // Keep a request outstanding across ndmreset.  dm_mem clears its halted,
-      // resuming, and FSM state, while dm_csrs retains the pending action
+      // Keep an unavailable request outstanding across ndmreset
+      write_debug_memory(HaltedAddr, 0);
+      write_debug_memory(ResumingAddr, 0);
+      expect_resume_ack(0, 1'b1);
       write_debug_memory(HaltedAddr, HartTwo);
       write_dmcontrol(20'(HartTwo), 1'b1, 1'b0);
       expect_resume_request(HartTwo, 1'b1);
-      write_dmcontrol(20'(HartTwo), 1'b1, 1'b1);
+      unavailable_i[HartTwo] = 1'b1;
+      write_dmcontrol(20'(HartTwo), 1'b0, 1'b1);
       @(posedge clk);
       #1ns;
       if (!ndmreset) begin
         $fatal(1, "ndmreset did not assert");
       end
       expect_halted(HartTwo, 1'b0);
+      expect_resume_ack(0, 1'b1);
       expect_resume_ack(HartTwo, 1'b0);
       expect_resume_request(HartTwo, 1'b1);
 
-      // Deassert ndmreset, re-establish halted state, and complete the retained
-      // request. The concurrent ResumingAddr write is suppressed by ndmreset
-      write_dmcontrol_and_resuming(20'(HartTwo), 1'b1, 1'b0, HartTwo);
+      // The unavailable request remains pending after reset while another hart
+      // executes an access register command
+      write_dmcontrol(20'(HartTwo), 1'b0, 1'b0);
       if (ndmreset) begin
         $fatal(1, "ndmreset did not deassert");
       end
-      expect_resume_ack(HartTwo, 1'b0);
-      write_debug_memory(HaltedAddr, HartTwo);
-      expect_halted(HartTwo, 1'b1);
-      write_debug_memory(ResumingAddr, HartTwo);
-      expect_resume_ack(HartTwo, 1'b1);
-      @(posedge clk);
-      expect_resume_request(HartTwo, 1'b0);
+      begin
+        logic [31:0] abstractcs_data;
+        dm::abstractcs_t abstractcs;
+        read_dmi(8'(dm::AbstractCS), abstractcs_data);
+        abstractcs = dm::abstractcs_t'(abstractcs_data);
+        if (abstractcs.busy) begin
+          $fatal(1, "ndmreset left AbstractCS busy for a pending resume");
+        end
+      end
+      write_debug_memory(HaltedAddr, 0);
+      execute_access_register_command(0);
+      unavailable_i[HartTwo] = 1'b0;
+      expect_resume_request(HartTwo, 1'b1);
     end else if (NrHarts == 1) begin
       // The singleton case still exercises stale-ack clearing and normal
-      // request completion before checking the full-vector reset behavior
+      // request completion before checking ndmreset acknowledgement retention
       write_debug_memory(HaltedAddr, 0);
       write_debug_memory(ResumingAddr, 0);
       expect_resume_ack(0, 1'b1);
@@ -429,20 +624,20 @@ module tb_dm_top_multihart_resume #(
       write_debug_memory(HaltedAddr, 0);
       expect_halted_vector('1);
       expect_resume_ack_vector('1);
-      write_dmcontrol(0, 1'b1, 1'b1);
+      write_dmcontrol(0, 1'b0, 1'b1);
       @(posedge clk);
       #1ns;
       if (!ndmreset) begin
         $fatal(1, "singleton ndmreset did not assert");
       end
       expect_halted_vector('0);
-      expect_resume_ack_vector('0);
+      expect_resume_ack_vector('1);
       write_dmcontrol(0, 1'b0, 1'b0);
       if (ndmreset) begin
         $fatal(1, "singleton ndmreset did not deassert");
       end
       expect_halted_vector('0);
-      expect_resume_ack_vector('0);
+      expect_resume_ack_vector('1);
     end else if (NrHarts == 4) begin
       // Power-of-two hart selection must preserve an unrelated stale
       // acknowledgement and support same-edge clear/ack traffic
@@ -481,7 +676,7 @@ module tb_dm_top_multihart_resume #(
       @(posedge clk);
       expect_resume_request(0, 1'b0);
 
-      // Set every halted bit so ndmreset must clear the complete vector
+      // Set every halted bit so ndmreset clears the halted cache only
       write_debug_memory(HaltedAddr, 0);
       write_debug_memory(HaltedAddr, 1);
       write_debug_memory(HaltedAddr, 2);
@@ -491,20 +686,76 @@ module tb_dm_top_multihart_resume #(
       expected_resumeack_before_ndmreset[0] = 1'b1;
       expected_resumeack_before_ndmreset[LastHart] = 1'b1;
       expect_resume_ack_vector(expected_resumeack_before_ndmreset);
-      write_dmcontrol(0, 1'b1, 1'b1);
+      write_dmcontrol(0, 1'b0, 1'b1);
       @(posedge clk);
       #1ns;
       if (!ndmreset) begin
         $fatal(1, "four-hart ndmreset did not assert");
       end
       expect_halted_vector('0);
-      expect_resume_ack_vector('0);
+      expect_resume_ack_vector(expected_resumeack_before_ndmreset);
       write_dmcontrol(0, 1'b0, 1'b0);
       if (ndmreset) begin
         $fatal(1, "four-hart ndmreset did not deassert");
       end
       expect_halted_vector('0);
-      expect_resume_ack_vector('0);
+      expect_resume_ack_vector(expected_resumeack_before_ndmreset);
+    end else if (NrHarts >= 5) begin
+      // Exercise the same per-hart behavior at non-power-of-two and wide-bus
+      // configurations, targeting the highest implemented hart
+      write_debug_memory(HaltedAddr, LastHart);
+      write_debug_memory(ResumingAddr, LastHart);
+      write_debug_memory(HaltedAddr, LastHart);
+      unavailable_i[LastHart] = 1'b1;
+      write_dmcontrol(20'(LastHart), 1'b1, 1'b0);
+      expect_resume_request(LastHart, 1'b0);
+      expect_resume_flag(LastHart, 1'b0);
+      expect_resume_ack(LastHart, 1'b0);
+      begin
+        logic [31:0] status_data;
+        dm::dmstatus_t status;
+        read_dmi(8'(dm::DMStatus), status_data);
+        status = dm::dmstatus_t'(status_data);
+        if (!status.allunavail || !status.anyunavail || status.allhalted ||
+            status.anyhalted || status.allresumeack || status.anyresumeack) begin
+          $fatal(1, "DMStatus did not report unavailable hart %0d correctly", LastHart);
+        end
+      end
+      unavailable_i[LastHart] = 1'b0;
+
+      write_debug_memory(HaltedAddr, 0);
+      write_dmcontrol(0, 1'b1, 1'b0);
+      write_debug_memory(HaltedAddr, LastHart);
+      execute_access_register_command(LastHart);
+      expect_resume_request(0, 1'b1);
+      write_debug_memory(ResumingAddr, 0);
+      @(posedge clk);
+      expect_resume_request(0, 1'b0);
+      expect_resume_ack(0, 1'b1);
+
+      write_debug_memory(HaltedAddr, LastHart);
+      write_dmcontrol(20'(LastHart), 1'b1, 1'b0);
+      expect_resume_flag(LastHart, 1'b1);
+      unavailable_i[LastHart] = 1'b1;
+      write_dmcontrol(20'(LastHart), 1'b0, 1'b1);
+      @(posedge clk);
+      expect_resume_flag(LastHart, 1'b0);
+      expect_resume_ack(0, 1'b1);
+      write_dmcontrol(20'(LastHart), 1'b0, 1'b0);
+      begin
+        logic [31:0] abstractcs_data;
+        dm::abstractcs_t abstractcs;
+        read_dmi(8'(dm::AbstractCS), abstractcs_data);
+        abstractcs = dm::abstractcs_t'(abstractcs_data);
+        if (abstractcs.busy) begin
+          $fatal(1, "ndmreset left AbstractCS busy for hart %0d resume", LastHart);
+        end
+      end
+      write_debug_memory(HaltedAddr, 0);
+      execute_access_register_command(0);
+      expect_resume_flag(LastHart, 1'b1);
+      expect_resume_request(LastHart, 1'b1);
+      unavailable_i[LastHart] = 1'b0;
     end else begin
       $fatal(1, "unsupported NrHarts=%0d", NrHarts);
     end

--- a/tb/dm_top/tb_dm_top_multihart_resume.sv
+++ b/tb/dm_top/tb_dm_top_multihart_resume.sv
@@ -155,7 +155,10 @@ module tb_dm_top_multihart_resume #(
     @(posedge clk);
   endtask
 
-  task automatic execute_access_register_command(input int unsigned command_hart);
+  task automatic execute_access_register_command(
+    input int unsigned command_hart,
+    input bit          expect_resume_rejection = 1'b0
+  );
     logic [BusWidth-1:0] flags_data;
     logic [31:0] abstractcs_data;
     dm::abstractcs_t abstractcs;
@@ -175,6 +178,20 @@ module tb_dm_top_multihart_resume #(
 
     read_dmi(8'(dm::AbstractCS), abstractcs_data);
     abstractcs = dm::abstractcs_t'(abstractcs_data);
+    if (expect_resume_rejection) begin
+      if (abstractcs.busy || abstractcs.cmderr != dm::CmdErrorHaltResume) begin
+        $fatal(1, "pending resume command was not rejected (busy=%0b cmderr=%0d)",
+               abstractcs.busy, abstractcs.cmderr);
+      end
+      read_debug_memory(12'(12'h400 + command_hart), flags_data);
+      if (flags_data[(command_hart % HartsPerFlagWord) * 8 +: 2] !== 2'b10) begin
+        $fatal(1, "pending resume command changed flags[%0d] (data=%08x)",
+               command_hart, flags_data);
+      end
+      expect_resume_request(command_hart, 1'b1);
+      write_dmi(8'(dm::AbstractCS), 32'h0000_0700);
+      return;
+    end
     if (!abstractcs.busy) begin
       $fatal(1, "access register command for hart %0d was lost while a resume was pending",
              command_hart);
@@ -470,6 +487,9 @@ module tb_dm_top_multihart_resume #(
       write_dmcontrol(0, 1'b1, 1'b0);
       expect_resume_request(0, 1'b1);
       expect_resume_ack(HartTwo, 1'b1);
+
+      // A pending resume must reject a command for the same hart
+      execute_access_register_command(0, 1'b1);
 
       // A pending resume for hart 0 must not block a command for hart 2
       write_debug_memory(HaltedAddr, HartTwo);

--- a/tb/dm_top/tb_dm_top_multihart_resume.sv
+++ b/tb/dm_top/tb_dm_top_multihart_resume.sv
@@ -119,7 +119,7 @@ module tb_dm_top_multihart_resume #(
     @(posedge clk);
   endtask
 
-  task automatic expect_dmcontrol_resumereq_zero;
+  task automatic expect_dmcontrol_write_only_fields_zero;
     if (clk !== 1'b0) begin
       @(negedge clk);
     end
@@ -133,8 +133,8 @@ module tb_dm_top_multihart_resume #(
     dmi_req_valid = 1'b0;
     #1ns;
     if (!dmi_resp_valid || dmi_resp.resp != dm::DTM_SUCCESS ||
-        dmi_resp.data[30] !== 1'b0) begin
-      $fatal(1, "DMControl resumereq is not read-zero (data=%08x)", dmi_resp.data);
+        dmi_resp.data[31:30] !== 2'b00) begin
+      $fatal(1, "DMControl haltreq/resumereq are not read-zero (data=%08x)", dmi_resp.data);
     end
     dmi_req.op = dm::DTM_WRITE;
     @(posedge clk);
@@ -287,6 +287,10 @@ module tb_dm_top_multihart_resume #(
       write_dmcontrol(0, 1'b1, 1'b0, 1'b1);
       expect_resume_request(0, 1'b0);
       expect_resume_ack(0, 1'b1);
+      expect_dmcontrol_write_only_fields_zero();
+      if (dut.haltreq[0] !== 1'b1) begin
+        $fatal(1, "DMControl read changed the active halt request");
+      end
       write_dmcontrol(0, 1'b1, 1'b0);
       expect_resume_request(0, 1'b1);
       expect_resume_ack(HartTwo, 1'b1);
@@ -299,7 +303,7 @@ module tb_dm_top_multihart_resume #(
       expect_resume_ack(HartTwo, 1'b0);
       // A non-requesting write changes hartsel but cannot cancel either action
       write_dmcontrol(20'(HartTwo), 1'b0, 1'b0);
-      expect_dmcontrol_resumereq_zero();
+      expect_dmcontrol_write_only_fields_zero();
       expect_resume_flag(0, 1'b1);
       expect_resume_flag(HartTwo, 1'b1);
 


### PR DESCRIPTION
Supersedes #164 and addresses #161.

Clear and evaluate resume acknowledgements per hart so stale acknowledgements cannot complete another hart’s resume request.  
Adds Verilator regressions testing for multi-hart configurations.