### PR TITLE
dm_csrs: ignore abstract commands when cmderr is non-zero

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -335,7 +335,7 @@ module dm_csrs #(
           resp_queue_inp.data = data_q[DataIndexWidth'(autoexecdata_idx)];
           if (!cmdbusy_i) begin
             // check whether we need to re-execute the command (just give a cmd_valid)
-            cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
+            if (cmderr_q == dm::CmdErrNone) cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
           // An abstract command was executing while one of the data registers was read
           end else begin
             resp_queue_inp.resp = dm::DTM_BUSY;
@@ -356,7 +356,7 @@ module dm_csrs #(
           if (!cmdbusy_i) begin
             // check whether we need to re-execute the command (just give a cmd_valid)
             // range of autoexecprogbuf is 31:16
-            cmd_valid_d = abstractauto_q.autoexecprogbuf[{1'b1, dmi_req_i.addr[3:0]}];
+            if (cmderr_q == dm::CmdErrNone) cmd_valid_d = abstractauto_q.autoexecprogbuf[{1'b1, dmi_req_i.addr[3:0]}];
 
           // An abstract command was executing while one of the progbuf registers was read
           end else begin
@@ -411,7 +411,7 @@ module dm_csrs #(
             if (!cmdbusy_i) begin
               data_d_dmi[dmi_req_i.addr[DataIndexWidth-1:0]] = dmi_req_i.data;
               // check whether we need to re-execute the command (just give a cmd_valid)
-              cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
+              if (cmderr_q == dm::CmdErrNone) cmd_valid_d = abstractauto_q.autoexecdata[autoexecdata_idx];
             //An abstract command was executing while one of the data registers was written
             end else begin
               resp_queue_inp.resp = dm::DTM_BUSY;
@@ -447,13 +447,13 @@ module dm_csrs #(
           end
         end
         dm::Command: begin
-          // writes are ignored if a command is already busy
-          if (!cmdbusy_i) begin
+          // writes are ignored if a command is already busy or if cmderr is non-zero
+          if (!cmdbusy_i && cmderr_q == dm::CmdErrNone) begin
             cmd_valid_d = 1'b1;
             command_d = dm::command_t'(dmi_req_i.data);
           // if there was an attempted to write during a busy execution
           // and the cmderror field is zero set the busy error
-          end else begin
+          end else if (cmdbusy_i) begin
             resp_queue_inp.resp = dm::DTM_BUSY;
             if (cmderr_q == dm::CmdErrNone) begin
               cmderr_d = dm::CmdErrBusy;
@@ -482,7 +482,7 @@ module dm_csrs #(
             // this should probably throw an error if executed during another command
             // was busy
             // range of autoexecprogbuf is 31:16
-            cmd_valid_d = abstractauto_q.autoexecprogbuf[{1'b1, dmi_req_i.addr[3:0]}];
+            if (cmderr_q == dm::CmdErrNone) cmd_valid_d = abstractauto_q.autoexecprogbuf[{1'b1, dmi_req_i.addr[3:0]}];
           //An abstract command was executing while one of the progbuf registers was written
           end else begin
             resp_queue_inp.resp = dm::DTM_BUSY;


### PR DESCRIPTION
This addresses the compliance bug tracked in openhwgroup/cva6#3498.

According to the RISC-V External Debug Support spec (0.13.2), if `cmderr` is non-zero, writes to the `command` register must be ignored and no new abstract command can be started. 

Currently, `dm_csrs` only gates command writes and `abstractauto` triggers on `!cmdbusy_i`. This allows a debugger to silently execute broken command sequences if it fails to check and clear `cmderr`.

This PR introduces a strict `cmderr_q == dm::CmdErrNone` gate to both execution paths to bring the DM into spec compliance.