### PR TITLE
implement ndmresetpending

### DIFF
--- a/src/dm_csrs.sv
+++ b/src/dm_csrs.sv
@@ -267,6 +267,7 @@ module dm_csrs #(
     dmstatus.authenticated = 1'b1;
     // we do not support halt-on-reset sequence
     dmstatus.hasresethaltreq = 1'b0;
+    dmstatus.ndmresetpending = dmcontrol_q.ndmreset;
     // TODO(zarubaf) things need to change here if we implement the array mask
     dmstatus.allhavereset = havereset_q_aligned[selected_hart];
     dmstatus.anyhavereset = havereset_q_aligned[selected_hart];

--- a/src/dm_pkg.sv
+++ b/src/dm_pkg.sv
@@ -99,7 +99,9 @@ package dm;
   localparam logic [2:0] CauseSingleStep = 3'h4;
 
   typedef struct packed {
-    logic [31:23] zero1;
+    logic [31:25] zero1;
+    logic         ndmresetpending;
+    logic         stickyunavail;
     logic         impebreak;
     logic [21:20] zero0;
     logic         allhavereset;


### PR DESCRIPTION
fixes #205. added ndmresetpending and stickyunavail to dmstatus_t struct so it aligns with the spec and sets ndmresetpending based on dmcontrol_q.ndmreset.